### PR TITLE
Add support for manual partition assignment

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,7 +49,7 @@ Run the following command to start the Kafka server:
           <parameter name="coordination">true</parameter>
           <parameter name="inbound.behavior">polling</parameter>
           <parameter name="value.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>
-          <parameter name="topic.names">test</parameter>
+          <parameter name="topic.name">test</parameter>
           <parameter name="poll.timeout">100</parameter>
           <parameter name="bootstrap.servers">localhost:9092</parameter>
           <parameter name="group.id">hello</parameter>
@@ -85,7 +85,7 @@ You can add the above inbound configuration via the WSO2 ESB Management Console 
           <parameter name="sequential">true</parameter>
           <parameter name="inbound.behavior">polling</parameter>
           <parameter name="value.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>
-          <parameter name="topic.names">test</parameter>
+          <parameter name="topic.name">test</parameter>
           <parameter name="poll.timeout">100</parameter>
           <parameter name="bootstrap.servers">localhost:9092</parameter>
           <parameter name="group.id">hello</parameter>
@@ -121,7 +121,7 @@ You can add the above inbound configuration via the WSO2 ESB Management Console 
           <parameter name="sequential">true</parameter>
           <parameter name="inbound.behavior">polling</parameter>
           <parameter name="value.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>
-          <parameter name="topic.names">test</parameter>
+          <parameter name="topic.name">test</parameter>
           <parameter name="poll.timeout">100</parameter>
           <parameter name="bootstrap.servers">localhost:9092</parameter>
           <parameter name="group.id">hello</parameter>
@@ -150,7 +150,7 @@ Given below are the descriptions of all possible parameters that you can set in 
 | bootstrap.servers | A list of host or port pairs that you can use to establish the initial connection to the Kafka cluster | Yes | localhost:9092, localhost:9093 |
 | key.deserializer | The deserialiser class for the key that implements the Deserializer interface | Yes | class |
 | value.deserializer | The deserialiser class for the value that implements the Deserializer interface | Yes | class |
-| topic.names | A comma-separated list of topic names to consume the messages | Yes | String |
+| topic.name | Topic name to consume the messages from | Yes | String |
 | group.id | The unique string that identifies the consumer group that a consumer belongs to | Yes | String |
 | contentType | The message content type | Yes | application/json, application/xml, text/plain |
 | pollTimeout | The amount of time to block the consumer to consume messages | Yes | Long |
@@ -162,6 +162,7 @@ Given below are the descriptions of all possible parameters that you can set in 
 | max.poll.records | The maximum number of records returned in a single call to poll. | Required for throttling | Integer |
 | enable.auto.commit | The default auto-commit is enabled. | Required for disable auto commit | true or false |
 | failure.retry.count | The offset set to the same record until the failure retry count exceeded. | The default value set to -1 | Positive Integer |
+| topic.partitions | A comma separated list of partition numbers of the topic to consume from | Required for manual partition assignment | String |
 
 For more information on Kafka configuration parameters, see the [Kafka Documentation](https://kafka.apache.org/documentation/#newconsumerconfigs).
 

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -33,7 +33,7 @@ public class KafkaConstants {
     public static final String KAFKA_KEY = "key";
 
     //Mandatory parameter for Kafka Inbound Endpoint.
-    public static final String TOPIC_NAMES = "topic.names";
+    public static final String TOPIC_NAME = "topic.name";
     public static final String TOPIC_PATTERN = "topic.pattern";
     public static final String CONTENT_TYPE = "contentType";
     public static final String BOOTSTRAP_SERVERS_NAME = "bootstrap.servers";
@@ -95,6 +95,7 @@ public class KafkaConstants {
     public static final String SSL_TRUSTMANAGER_ALGORITHM = "ssl.trustmanager.algorithm";
     public static final String SET_ROLLBACK_ONLY = "SET_ROLLBACK_ONLY";
     public static final String FAILURE_RETRY_COUNT = "failure.retry.count";
+    public static final String TOPIC_PARTITIONS = "topic.partitions";
 
     //Kafka Inbound endpoint parameter's default value.
     public static final String ENABLE_AUTO_COMMIT_DEFAULT = "true";


### PR DESCRIPTION
## Purpose

- Add support for manual partition assignment
- Allow only one topic to be configured per inbound endpoint.

> Resolves wso2/product-ei#5016

## Approach

- The `topic.names` configuration will not be further supported. Instead, `topic.name` parameter is introduced to specify the topic which the consumer will consume messages from.

- `topic.partitions` parameter will configure a comma separated list of partitions of the topic which the consumer has subscribed to.

E.g:
```
<?xml version="1.0" encoding="UTF-8"?>
<inboundEndpoint xmlns="http://ws.apache.org/ns/synapse"
                 name="kafkaIEP"
                 sequence="request"
                 onError="fault"
                 class="org.wso2.carbon.inbound.kafka.KafkaMessageConsumer"
                 suspend="false">
   <parameters>
      <parameter name="inbound.behavior">polling</parameter>
      <parameter name="interval">10</parameter>
      <parameter name="sequential">true</parameter>
      <parameter name="coordination">true</parameter>
      <parameter name="key.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>
      <parameter name="value.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>
      <parameter name="poll.timeout">100</parameter>
      <parameter name="group.id">hello</parameter>
      <parameter name="bootstrap.servers">localhost:9092</parameter>
      <parameter name="topic.name">test</parameter>
      <parameter name="topic.partitions">0,1</parameter>
      <parameter name="contentType">application/json</parameter>
   </parameters>
</inboundEndpoint>
```
