### PR TITLE
Remove depricated methods and upgrade kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.synapse.inbound.kafka</groupId>
     <artifactId>org.apache.synapse.kafka.poll</artifactId>
-    <version>1.0.13-SNAPSHOT</version>
+    <version>1.1.1-SNAPSHOT</version>
     <name>Kafka Polling Consumer</name>
     <url>http://wso2.org</url>
     <packaging>bundle</packaging>
@@ -155,6 +155,6 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
     </distributionManagement>
     <properties>
         <carbon.mediation.version>4.4.10</carbon.mediation.version>
-        <kafka.version>2.2.1</kafka.version>
+        <kafka.version>3.3.1</kafka.version>
     </properties>
 </project>

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -186,7 +186,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         msgCtx.setProperty(KafkaConstants.KAFKA_MESSAGE_VALUE, record.value());
         msgCtx.setProperty(KafkaConstants.KAFKA_OFFSET, record.offset());
         //noinspection deprecation
-        msgCtx.setProperty(KafkaConstants.KAFKA_CHECKSUM, record.checksum());
+        // record.checksum() is deprecated, hence removed.
         msgCtx.setProperty(KafkaConstants.KAFKA_TIMESTAMP, record.timestamp());
         msgCtx.setProperty(KafkaConstants.KAFKA_TIMESTAMP_TYPE, record.timestampType());
         msgCtx.setProperty(KafkaConstants.KAFKA_TOPIC, record.topic());


### PR DESCRIPTION
## Purpose
> Remove the depricated checksum() and
upgrade to next kafka major version 3.x
fixes wso2/api-manager/issues/913
