### PR TITLE
Handle poison pills

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
     <repositories>
         <repository>
             <id>wso2-maven2-repository</id>
-            <url>http://dist.wso2.org/maven2</url>
+            <url>https://dist.wso2.org/maven2</url>
         </repository>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
         <repository>
             <id>atlassian-contrib</id>
@@ -77,7 +77,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
         <repository>
             <id>wso2-nexus</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -87,7 +87,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
         <repository>
             <id>wso2</id>
             <name>WSO2 internal Repository</name>
-            <url>http://dist.wso2.org/maven2/</url>
+            <url>https://dist.wso2.org/maven2/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -97,7 +97,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
         <repository>
             <id>wso2.snapshots</id>
             <name>WSO2 Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>
@@ -146,7 +146,8 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
                     <instructions>
                         <Bundle-SymbolicName>${pom.artifactId}</Bundle-SymbolicName>
                         <Export-Package>
-                            org.wso2.carbon.inbound.kafka.*;version="${project.version}"
+                            org.wso2.carbon.inbound.kafka.*;version="${project.version}",
+                            org.wso2.carbon.inbound.kafka.deserializer.*;version="${project.version}"
                         </Export-Package>
                         <Import-Package>
                             !javax.xml.namespace,

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -145,7 +145,7 @@ public class KafkaConstants {
             "org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer";
 
     // Error codes
-    public static final String POISON_PILL_DETECTED = "700601";
-    public static final String MAX_RETRY_COUNT_EXCEEDED = "700602";
+    public static final String POISON_PILL_DETECTED = "700510";
+    public static final String RETRY_EXHAUSTED = "700511";
 
 }

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -39,6 +39,8 @@ public class KafkaConstants {
     public static final String BOOTSTRAP_SERVERS_NAME = "bootstrap.servers";
     public static final String KEY_DESERIALIZER = "key.deserializer";
     public static final String VALUE_DESERIALIZER = "value.deserializer";
+    public static final String KEY_DELEGATE_DESERIALIZER = "key.delegate.deserializer";
+    public static final String VALUE_DELEGATE_DESERIALIZER = "value.delegate.deserializer";
     public static final String GROUP_ID = "group.id";
     public static final String POLL_TIMEOUT = "poll.timeout";
 
@@ -135,5 +137,15 @@ public class KafkaConstants {
     public static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
 
     public static final String KAFKA_AVRO_DESERIALIZER = "io.confluent.kafka.serializers.KafkaAvroDeserializer";
+
+    // Error Handling Deserializer properties
+    public static final String KEY_DESERIALIZER_EXCEPTION_HEADER = "KafkaInboundKeyDeserializerException";
+    public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = "KafkaInboundValueDeserializerException";
+    public static final String DEFAULT_ERROR_HANDLING_DESERIALIZER_CLASS =
+            "org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer";
+
+    // Error codes
+    public static final String POISON_PILL_DETECTED = "700601";
+    public static final String MAX_RETRY_COUNT_EXCEEDED = "700602";
 
 }

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Header;
@@ -44,7 +45,9 @@ import org.wso2.carbon.inbound.endpoint.protocol.generic.GenericPollingConsumer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -130,25 +133,41 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 // Fixes - CS0196510
                 Object value  = record.value();
                 boolean isConsumed = false;
+                boolean poisonPillDetected = false;
                 if ( value == null ) {
+                    if (isPoisonPill(record)) {
+                        poisonPillDetected = true;
+                        log.warn("A poison pill was detected and will be skipped. The respective error details"
+                                + " will be injected to the `onError` sequence: " + this.onErrorSeq
+                                + " of Kafka Inbound Endpoint: " + name);
+                        handlePoisonPill(record, msgCtx);
+                    } else {
+                        log.warn("A null record is passed and skipped");
+                    }
                     isConsumed = true;
-                    log.warn("A null record is passed and skipped");
                 } else {
                     isConsumed = injectMessage(value.toString(), contentType, msgCtx);
                 }
 
-                // Manually commit if the record is consumed successfully and auto-commit
-                // set to false
-                if (isConsumed && isDisableAutoCommit) {
-                    consumer.commitSync(Collections.singletonMap(topicPartition,
-                            new OffsetAndMetadata(recordOffset + 1)));
-                // if SET_ROLLBACK_ONLY property set to true isConsumed will be false hence
-                // setting the offset to the current record. It ends up in a loop when an error
-                // scenario. For example, if a message always ends up hitting the fault sequence.
-                } else if (!isConsumed && isDisableAutoCommit) {
-                    consumer.seek(topicPartition, recordOffset);
-                    retryCounter = retryCounter + 1;
-                    break;
+                if (isDisableAutoCommit) {
+                    if (poisonPillDetected) {
+                        log.info("The poison pill is skipped by setting the offset to the next record.");
+                        consumer.seek(topicPartition, recordOffset + 1);
+                        continue;
+                    }
+                    // Manually commit if the record is consumed successfully and auto-commit
+                    // set to false
+                    if (isConsumed) {
+                        consumer.commitSync(Collections.singletonMap(topicPartition,
+                                new OffsetAndMetadata(recordOffset + 1)));
+                    // if SET_ROLLBACK_ONLY property set to true isConsumed will be false hence
+                    // setting the offset to the current record. It ends up in a loop when an error
+                    // scenario. For example, if a message always ends up hitting the fault sequence.
+                    } else {
+                        consumer.seek(topicPartition, recordOffset);
+                        retryCounter = retryCounter + 1;
+                        break;
+                    }
                 }
             }
         }
@@ -157,6 +176,57 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             log.warn("The offset set to the next record since failure retry count exceeded.");
             consumer.seek(topicPartition, recordOffset + 1);
             retryCounter = 0;
+        }
+    }
+
+    /**
+     * A poison pill (in the context of Kafka) is a record that has been produced to a Kafka topic
+     * and always fails when consumed, no matter how many times it is attempted. At this level, a record
+     * is considered as a poison pill if the record headers contain either 'KafkaInboundKeyDeserializerException' or
+     * 'KafkaInboundValueDeserializerException' header in the record headers.
+     *
+     * @param record the consumer record
+     * @return true if the consumer record's headers contain either 'KafkaInboundKeyDeserializerException' or
+     * 'KafkaInboundValueDeserializerException' header.
+     */
+    private boolean isPoisonPill(ConsumerRecord record) {
+        return record.headers().lastHeader(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER) != null
+                || record.headers().lastHeader(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER) != null;
+
+    }
+
+    /**
+     * Extract the exception details from the deserialization exception headers and inject
+     * those details to error sequence.
+     *
+     * @param record ConsumerRecord instance
+     * @param msgCtx Synapse message context
+     */
+    private void handlePoisonPill(ConsumerRecord record, MessageContext msgCtx) {
+        Header keyDeserializationExceptionHeader = record.headers()
+                .lastHeader(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER);
+        Header valueDeserializationExceptionHeader = record.headers()
+                .lastHeader(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+        byte [] value;
+        if (keyDeserializationExceptionHeader != null) {
+            value = keyDeserializationExceptionHeader.value();
+        } else {
+            value = valueDeserializationExceptionHeader.value();
+        }
+
+        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(value))) {
+            // Read the KafkaException from the ObjectInputStream
+            KafkaException error = (KafkaException) objectInputStream.readObject();
+            injectErrorMessage(error.getMessage(), KafkaConstants.POISON_PILL_DETECTED, msgCtx);
+
+        } catch (ClassNotFoundException e) {
+            log.error("Could not deserialize the poison pill message into a 'KafkaException'. Hence, failed to"
+                    + " inject the poison pill error details to 'onError' sequence: " + this.onErrorSeq
+                    + " of Kafka Inbound Endpoint: " + name, e);
+        } catch (IOException e) {
+            log.error("Could not deserialize the KafkaException while handling the poison pill. Hence, failed to"
+                    + " inject the poison pill error details to 'onError' sequence: " + this.onErrorSeq
+                    + " of Kafka Inbound Endpoint: " + name, e);
         }
     }
 
@@ -277,6 +347,50 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     }
 
     /**
+     * Inject error message details as MessageContext properties to the 'onError' sequence that is configured
+     * in the Kafka Inbound Endpoint. The SET_ROLLBACK_ONLY property is ignored here as the fault sequence
+     * is purposefully and forcefully invoked.
+     *
+     * @param message error message to be set in the 'ERROR_MESSAGE' MessageContext property.
+     * @param msgCtx Synapse message context.
+     * @return false if the 'onError' sequence name is not configured in the Kafka Inbound Endpoint or
+     * if a sequence for the configured name is not found or if an error occurred while invoking the
+     * handlers in the Synapse Environment prior to mediate to the sequence. Otherwise, return true.
+     */
+    private boolean injectErrorMessage(String message, String errorCode, MessageContext msgCtx) {
+
+        if (StringUtils.isEmpty(this.onErrorSeq)) {
+            log.error("Could not mediate the error message as the 'onError' sequence name not specified for Kafka "
+                    + "Inbound Endpoint: " + name + ". Hence, no retry attempted on failure.");
+            return false;
+        }
+
+        SequenceMediator errorSeq = (SequenceMediator) this.synapseEnvironment.getSynapseConfiguration().getSequence(
+                this.onErrorSeq);
+        if (errorSeq == null) {
+            log.error("Could not mediate the error message as the 'onError' Sequence with name: " + this.onErrorSeq
+                    + " not found. Hence, no retry attempted on failure.");
+            return false;
+        }
+
+        // Populate error details to the message context as properties
+        msgCtx.setProperty(SynapseConstants.ERROR_CODE, errorCode);
+        msgCtx.setProperty(SynapseConstants.ERROR_MESSAGE, message);
+
+        if (log.isDebugEnabled()) {
+            log.debug("injecting message to 'onError' sequence: " + this.onErrorSeq
+                    + " of Kafka Inbound Endpoint: " + name);
+        }
+        if (!this.synapseEnvironment.injectInbound(msgCtx, errorSeq, this.sequential)) {
+            log.warn("Could not inject the error details to 'onError' sequence: " + this.onErrorSeq
+                    + " of Kafka Inbound Endpoint: " + name);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Check the SET_ROLLBACK_ONLY property set to true
      *
      * @param msgCtx SynapseMessageContext
@@ -305,7 +419,19 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
         bootstrapServersName = properties.getProperty(KafkaConstants.BOOTSTRAP_SERVERS_NAME);
         keyDeserializer = properties.getProperty(KafkaConstants.KEY_DESERIALIZER);
+        if (KafkaConstants.DEFAULT_ERROR_HANDLING_DESERIALIZER_CLASS.equals(keyDeserializer)) {
+            if (StringUtils.isEmpty(properties.getProperty(KafkaConstants.KEY_DELEGATE_DESERIALIZER))) {
+                throw new SynapseException("The 'key.delegate.deserializer' property must not be empty when "
+                        + "'key.deserializer' is configured with the default error handling deserializer.");
+            }
+        }
         valueDeserializer = properties.getProperty(KafkaConstants.VALUE_DESERIALIZER);
+        if (KafkaConstants.DEFAULT_ERROR_HANDLING_DESERIALIZER_CLASS.equals(valueDeserializer)) {
+            if (StringUtils.isEmpty(properties.getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER))) {
+                throw new SynapseException("The 'value.delegate.deserializer' property must not be empty when "
+                        + "'value.deserializer' is configured with the default error handling deserializer.");
+            }
+        }
         groupId = properties.getProperty(KafkaConstants.GROUP_ID);
         pollTimeout = properties.getProperty(KafkaConstants.POLL_TIMEOUT);
         // check whether the properties have topic name or topic pattern
@@ -421,7 +547,16 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 .getProperty(KafkaConstants.MAX_PARTITION_FETCH_BYTES,
                         KafkaConstants.MAX_PARTITION_FETCH_BYTES_DEFAULT));
 
-        if(properties.getProperty(KafkaConstants.VALUE_DESERIALIZER).equalsIgnoreCase(KafkaConstants.KAFKA_AVRO_DESERIALIZER)){
+        kafkaProperties.put(KafkaConstants.KEY_DELEGATE_DESERIALIZER, properties
+                .getProperty(KafkaConstants.KEY_DELEGATE_DESERIALIZER));
+
+        kafkaProperties.put(KafkaConstants.VALUE_DELEGATE_DESERIALIZER, properties
+                .getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER));
+
+        if (properties.getProperty(KafkaConstants.VALUE_DESERIALIZER)
+                .equalsIgnoreCase(KafkaConstants.KAFKA_AVRO_DESERIALIZER)
+                || properties.getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER)
+                .equalsIgnoreCase(KafkaConstants.KAFKA_AVRO_DESERIALIZER)){
             kafkaProperties.put(KafkaConstants.SCHEMA_REGISTRY_URL, properties.
                     getProperty(KafkaConstants.SCHEMA_REGISTRY_URL, KafkaConstants.DEFAULT_SCHEMA_REGISTRY_URL));
 

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -137,9 +137,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 if ( value == null ) {
                     if (isPoisonPill(record)) {
                         poisonPillDetected = true;
-                        log.warn("A poison pill was detected and will be skipped. The respective error details"
-                                + " will be injected to the `onError` sequence: " + this.onErrorSeq
-                                + " of Kafka Inbound Endpoint: " + name);
+                        log.warn("A poison pill was detected for Topic: " + record.topic()
+                                + ", Partition No: " + record.partition()
+                                + ", Offset: " + record.offset()
+                                + ". The respective error details will be injected to the `onError` sequence: "
+                                + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name);
                         handlePoisonPill(record, msgCtx);
                     } else {
                         log.warn("A null record is passed and skipped");
@@ -151,7 +153,8 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
                 if (isDisableAutoCommit) {
                     if (poisonPillDetected) {
-                        log.info("The poison pill is skipped by setting the offset to the next record.");
+                        log.info("The poison pill at offset " + record.offset()
+                                + " is skipped by setting the offset to the next record.");
                         consumer.seek(topicPartition, recordOffset + 1);
                         continue;
                     }

--- a/src/main/java/org/wso2/carbon/inbound/kafka/deserializer/DeserializationException.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/deserializer/DeserializationException.java
@@ -79,11 +79,11 @@ public class DeserializationException extends KafkaException {
     @Override
     public String getMessage() {
 
-        return "Error details{ message=" + super.getMessage()
+        return "Error details{message=" + super.getMessage()
                 + ", topic=" + this.topic
                 + ", data=" + Arrays.toString(this.data)
                 + ", cause=" + getCause().getMessage()
-                + " }";
+                + "}";
     }
 
 }

--- a/src/main/java/org/wso2/carbon/inbound/kafka/deserializer/DeserializationException.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/deserializer/DeserializationException.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.inbound.kafka.deserializer;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Arrays;
+
+public class DeserializationException extends KafkaException {
+
+    private final String topic;
+    private transient Headers headers;
+    private final byte[] data;
+    private final boolean isKey;
+
+    /**
+     * Construct an instance with the provided properties.
+     * @param message the message.
+     * @param data the data (value or key).
+     * @param isKey true if the exception occurred while deserializing the key.
+     * @param cause the cause.
+     */
+    public DeserializationException(String message, String topic, byte[] data, boolean isKey, Throwable cause) {
+        super(message, cause);
+        this.topic = topic;
+        this.data = data;
+        this.isKey = isKey;
+    }
+
+    /**
+     * Get the data that failed deserialization (value or key).
+     * @return the data.
+     */
+    public byte[] getData() {
+        return this.data;
+    }
+
+    /**
+     * True if deserialization of the key failed, otherwise deserialization of the value
+     * failed.
+     * @return true for the key.
+     */
+    public boolean isKey() {
+        return this.isKey;
+    }
+
+    /**
+     * Get the headers.
+     * @return the headers.
+     */
+    public Headers getHeaders() {
+        return this.headers;
+    }
+
+    /**
+     * Set the headers.
+     * @param headers the headers.
+     */
+    public void setHeaders(Headers headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public String getMessage() {
+
+        return "Error details{ message=" + super.getMessage()
+                + ", topic=" + this.topic
+                + ", data=" + Arrays.toString(this.data)
+                + ", cause=" + getCause().getMessage()
+                + " }";
+    }
+
+}

--- a/src/main/java/org/wso2/carbon/inbound/kafka/deserializer/ErrorHandlingDeserializer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/deserializer/ErrorHandlingDeserializer.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.inbound.kafka.deserializer;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.synapse.SynapseException;
+import org.wso2.carbon.inbound.kafka.KafkaConstants;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+
+public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
+
+    private static final Log LOGGER = LogFactory.getLog(ErrorHandlingDeserializer.class);
+
+    private Deserializer<T> delegate;
+
+    private boolean isForKey;
+
+    public ErrorHandlingDeserializer() {
+    }
+
+    public ErrorHandlingDeserializer(Deserializer<T> delegate) {
+        this.delegate = setupDelegate(delegate);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+
+        if (this.delegate == null) {
+            setupDelegate(configs, isKey ? KafkaConstants.KEY_DELEGATE_DESERIALIZER
+                    : KafkaConstants.VALUE_DELEGATE_DESERIALIZER);
+        }
+        if (this.delegate == null) {
+            LOGGER.error("No delegate deserializer configured");
+        }
+        this.delegate.configure(configs, isKey);
+        this.isForKey = isKey;
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+
+        try {
+            return this.delegate.deserialize(topic, data);
+        } catch (Exception e) {
+            Iterable<Header> recordHeaders = null;
+            Headers headers = new RecordHeaders(recordHeaders);
+            deserializationException(topic, headers, data, e, this.isForKey);
+            return null;
+        }
+    }
+
+    @Override
+    public T deserialize(String topic, Headers headers, byte[] data) {
+
+        try {
+            if (this.isForKey) {
+                headers.remove(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER);
+            }
+            else {
+                headers.remove(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+            }
+            return this.delegate.deserialize(topic, headers, data);
+        } catch (Exception e) {
+            deserializationException(topic, headers, data, e, this.isForKey);
+            return null;
+        }
+    }
+
+    @Override
+    public void close() {
+
+        Deserializer.super.close();
+    }
+
+    private void setupDelegate(Map<String, ?> configs, String configKey) {
+        if (configs.containsKey(configKey)) {
+            try {
+                Object value = configs.get(configKey);
+                ClassLoader classLoader = getDefaultClassLoader();
+                if (classLoader != null) {
+                    Class<?> clazz = classLoader.loadClass(value.toString());
+                    this.delegate = setupDelegate(clazz.getDeclaredConstructor().newInstance());
+                } else {
+                    throw new SynapseException("Could not setup the delegate as the ClassLoader was not accessible.");
+                }
+            } catch (Exception e) {
+                throw new SynapseException("Could not setup the delegate.", e);
+            }
+        }
+    }
+
+    private Deserializer<T> setupDelegate(Object delegate) {
+        if (!(delegate instanceof Deserializer)) {
+            throw new SynapseException("'delegate' must be a 'Deserializer'");
+        }
+        return (Deserializer<T>) delegate;
+    }
+
+    /**
+     * Populate the record headers with a serialized {@link DeserializationException}.
+     * @param topic the topic.
+     * @param headers the headers.
+     * @param data the data.
+     * @param ex the exception.
+     * @param isForKeyArg true if this is a key deserialization problem, otherwise value.
+     */
+    private static void deserializationException(String topic, Headers headers, byte[] data, Exception ex,
+                                                boolean isForKeyArg) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        DeserializationException exception =
+                new DeserializationException("Failed to deserialize the " + getType(isForKeyArg), topic, data,
+                        isForKeyArg, ex);
+        try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
+            oos.writeObject(exception);
+        }
+        catch (IOException e) {
+            stream = new ByteArrayOutputStream();
+            try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
+                exception = new DeserializationException("Failed to deserialize the "  + getType(isForKeyArg), topic,
+                        data, isForKeyArg, new RuntimeException("Could not serialize type "
+                        + ex.getClass().getName() + " with message " + e.getMessage()
+                        + ". Original exception message: " + ex.getMessage()));
+                oos.writeObject(exception);
+            } catch (IOException ex2) {
+                LOGGER.error("Poison pill is detected, but will be skipped as Could not serialize a "
+                        + "DeserializationException. " + ex2.getMessage());
+                return;
+            }
+        }
+        headers.add(new RecordHeader(isForKeyArg
+                        ? KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER
+                        : KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER,
+                        stream.toByteArray()));
+    }
+
+    private static String getType(boolean isForKey) {
+        if (isForKey) {
+            return "Key";
+        }
+        return "Value";
+    }
+
+    private static ClassLoader getDefaultClassLoader() {
+        ClassLoader cl = null;
+        try {
+            cl = Thread.currentThread().getContextClassLoader();
+        } catch (Throwable ex) {
+            // Cannot access thread context ClassLoader - falling back...
+        }
+        if (cl == null) {
+            // No thread context class loader -> use class loader of this class.
+            cl = ErrorHandlingDeserializer.class.getClassLoader();
+            if (cl == null) {
+                // getClassLoader() returning null indicates the bootstrap ClassLoader
+                try {
+                    cl = ClassLoader.getSystemClassLoader();
+                } catch (Throwable ex) {
+                    // Cannot access system ClassLoader
+                }
+            }
+        }
+        return cl;
+    }
+}


### PR DESCRIPTION
## Purpose
A poison pill (in the context of Kafka) is a record that has been produced to a Kafka topic and always fails when consumed, no matter how many times it is attempted. With the current implementation, when a poison message is put in the queue, the Kafka inbound consumer makes an endless cycle to consume that and wastes valuable CPU time. This PR fixes that issue by identifying those poison pills and handling them accordingly.

## Goals
Identify and handle poison pills while consuming them to avoid an endless loop.

## Approach
When a deserializer fails to deserialize a message (poison pill), the current Kafka Inbound Endpoint has no way to handle the problem, because it occurs before the poll() returns. To solve this problem, the ErrorHandlingDeserializer has been introduced. This deserializer delegates to a real deserializer (key or value). If the delegate fails to deserialize the record content, the ErrorHandlingDeserializer returns a null value and a DeserializationException in a header that contains the cause and the raw bytes. 

Upon discovery of a poison pill, the error details will be injected into the 'onError' sequence that is configured in the Kafka Inbound Endpoint through the below message context properties. Also, if the `enable.auto.commit` property is set to false, this particular message/record will not be committed to the topic, hence will be left in the queue.

ERROR_CODE - 700601
ERROR_MESSAGE - Failed to deserialize .........

-----------------------------------------------------

Default error handling deserializer - `org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer`
Newly introduced properties -
- key.delegate.deserializer - The actual key deserializer that the error handling deserializer should delegate to.
- value.delegate.deserializer - The actual value deserializer that the error handling deserializer should delegate to.

In order to enable error handling of poison pills, one may follow the below steps.

Suppose the error handling should be done for the Key and the real key deserializer to be used is `org.apache.kafka.common.serialization.StringDeserializer`. Then, the inbound endpoint config should be updated as follow.

<parameter name="key.deserializer">org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer</parameter>
<parameter name="key.delegate.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>

Similarly, for Value,

<parameter name="value.deserializer">org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer</parameter>
<parameter name="value.delegate.deserializer">org.apache.kafka.common.serialization.StringDeserializer</parameter>

**One should note that if the `key.deserializer` or the `value.deserializer` is configured to the default error handling deserializer - `org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer`, then `key.delegate.deserializer` and `value.delegate.deserializer` parameters are mandatory with the values of the actual deserializes.
