### PR TITLE
Introduce a parameter to configure failure retry interval

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -97,6 +97,7 @@ public class KafkaConstants {
     public static final String SSL_TRUSTMANAGER_ALGORITHM = "ssl.trustmanager.algorithm";
     public static final String SET_ROLLBACK_ONLY = "SET_ROLLBACK_ONLY";
     public static final String FAILURE_RETRY_COUNT = "failure.retry.count";
+    public static final String FAILURE_RETRY_INTERVAL = "failure.retry.interval";
     public static final String TOPIC_PARTITIONS = "topic.partitions";
 
     //Kafka Inbound endpoint parameter's default value.


### PR DESCRIPTION
## Purpose
Introducing the parameter `failure.retry.interval` to configure an interval between two retries for failures that happen while injecting for the inbound mediation.

Also, this PR improves the logging to allow more visibility.

## Approach
According to the current implementation, when the Kafka message was not successfully injected into the inbound mediation whenever the `enable.auto.commit` is set to false, that message will be retried for the max of the value of `failure.retry.count`. This PR introduces a way to configure an interval between such two retries.

Normally, this next retry happens with the next poll. Hence, the effective retry interval would be the greater of poll interval (`interval`) and failure retry interval (`failure.retry.interval`).

