### PR TITLE
Support SASL_SSL security protocol with OAUTHBEARER mechanism

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -100,6 +100,13 @@ public class KafkaConstants {
     public static final String FAILURE_RETRY_COUNT = "failure.retry.count";
     public static final String FAILURE_RETRY_INTERVAL = "failure.retry.interval";
     public static final String TOPIC_PARTITIONS = "topic.partitions";
+    public static final String SASL_OAUTHBEARER_TOKEN_ENDPOINT = "sasl.oauthbearer.token.endpoint.url";
+    public static final String SASL_OAUTHBEARER_SCOPE_CLAIM_NAME = "sasl.oauthbearer.scope.claim.name";
+    public static final String SASL_LOGIN_CONNECT_TIMEOUT = "sasl.login.connect.timeout.ms";
+    public static final String SASL_LOGIN_READ_TIMEOUT = "sasl.login.read.timeout.ms";
+    public static final String SASL_LOGIN_RETRY_BACKOFF = "sasl.login.retry.backoff.ms";
+    public static final String SASL_LOGIN_RETRY_BACKOFF_MAX = "sasl.login.retry.backoff.max.ms";
+    public static final String KAFKA_LOGIN_CALLBACK_HANDLER_CLASS = "sasl.login.callback.handler.class";
 
     //Kafka Inbound endpoint parameter's default value.
     public static final String ENABLE_AUTO_COMMIT_DEFAULT = "true";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -824,5 +824,40 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             kafkaProperties.put(KafkaConstants.SSL_TRUSTMANAGER_ALGORITHM,
                     properties.getProperty(KafkaConstants.SSL_TRUSTMANAGER_ALGORITHM));
         }
+
+        if (properties.getProperty(KafkaConstants.SASL_OAUTHBEARER_TOKEN_ENDPOINT) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_OAUTHBEARER_TOKEN_ENDPOINT,
+                    properties.getProperty(KafkaConstants.SASL_OAUTHBEARER_TOKEN_ENDPOINT));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME,
+                    properties.getProperty(KafkaConstants.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME));
+        }
+
+        if (properties.getProperty(KafkaConstants.KAFKA_LOGIN_CALLBACK_HANDLER_CLASS) != null) {
+            kafkaProperties.put(KafkaConstants.KAFKA_LOGIN_CALLBACK_HANDLER_CLASS,
+                    properties.getProperty(KafkaConstants.KAFKA_LOGIN_CALLBACK_HANDLER_CLASS));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_LOGIN_CONNECT_TIMEOUT) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_LOGIN_CONNECT_TIMEOUT,
+                    properties.getProperty(KafkaConstants.SASL_LOGIN_CONNECT_TIMEOUT));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_LOGIN_READ_TIMEOUT) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_LOGIN_READ_TIMEOUT,
+                    properties.getProperty(KafkaConstants.SASL_LOGIN_READ_TIMEOUT));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_LOGIN_RETRY_BACKOFF) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_LOGIN_RETRY_BACKOFF,
+                    properties.getProperty(KafkaConstants.SASL_LOGIN_RETRY_BACKOFF));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_LOGIN_RETRY_BACKOFF_MAX) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_LOGIN_RETRY_BACKOFF_MAX,
+                    properties.getProperty(KafkaConstants.SASL_LOGIN_RETRY_BACKOFF_MAX));
+        }
     }
 }


### PR DESCRIPTION
## Purpose

This PR adds the support to configure the SASL_SSL security protocol with the OAUTHBEARER mechanism.

- **sasl.login.callback.handler.class** - The fully qualified name of a SASL login callback handler class that implements the AuthenticateCallbackHandler interface.
- **sasl.oauthbearer.token.endpoint.url** - The URL for the OAuth/OIDC identity provider
- **sasl.oauthbearer.scope.claim.name** - (optional) The override name of the scope claim
- **sasl.login.connect.timeout.ms** - (optional) The duration, in milliseconds, for HTTPS connect timeout
- **sasl.login.read.timeout.ms** - (optional) The duration, in milliseconds, for HTTPS read timeout
- **sasl.login.retry.backoff.ms** - (optional) The duration, in milliseconds, to wait between HTTPS call attempts
- **sasl.login.retry.backoff.max.ms** - (optional) The maximum duration, in milliseconds, for HTTPS call attempts

