### PR TITLE
Update the failed message consumption logic

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -188,7 +188,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                     // scenario. For example, if a message always ends up hitting the fault sequence.
                     } else {
                         failedRecord = record;
-                        consumer.seek(topicPartition, recordOffset);
                         if (failureRetryInterval > 0 && retryCounter < failureRetryCount) {
                             try {
                                 if (log.isDebugEnabled()) {
@@ -202,6 +201,9 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                             }
                         }
                         retryCounter = retryCounter + 1;
+                        if (retryCounter < failureRetryCount) {
+                            consumer.seek(topicPartition, recordOffset);
+                        }
                         break;
                     }
                 }


### PR DESCRIPTION
$subject

Avoid calling the `seek(TopicPartition partition, long offset)` API twice with the old and new offset when the retry count reaches the max failure retry count. 