### PR TITLE
Add missing kafka configuration properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.synapse.inbound.kafka</groupId>
     <artifactId>org.apache.synapse.kafka.poll</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.2.1</version>
     <name>Kafka Polling Consumer</name>
     <url>http://wso2.org</url>
     <packaging>bundle</packaging>

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -67,6 +67,8 @@ public class KafkaConstants {
     public static final String RECEIVER_BUFFER_BYTES = "receive.buffer.bytes";
     public static final String REQUEST_TIMEOUT_MS = "request.timeout.ms";
     public static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
+    public static final String SASL_CLIENT_CALLBACK_HANDLER_CLASS = "sasl.client.callback.handler.class";
+    public static final String SASL_LOGIN_CLASS = "sasl.login.class";
     public static final String SASL_KERBEROS_SERVICE_NAME = "sasl.kerberos.service.name";
     public static final String SASL_MECANISM = "sasl.mechanism";
     public static final String SECURITY_PROTOCOL = "security.protocol";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -617,16 +617,20 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 .getProperty(KafkaConstants.MAX_PARTITION_FETCH_BYTES,
                         KafkaConstants.MAX_PARTITION_FETCH_BYTES_DEFAULT));
 
-        kafkaProperties.put(KafkaConstants.KEY_DELEGATE_DESERIALIZER, properties
-                .getProperty(KafkaConstants.KEY_DELEGATE_DESERIALIZER));
+        if (properties.getProperty(KafkaConstants.KEY_DELEGATE_DESERIALIZER) != null) {
+            kafkaProperties.put(KafkaConstants.KEY_DELEGATE_DESERIALIZER, properties
+                    .getProperty(KafkaConstants.KEY_DELEGATE_DESERIALIZER));
+        }
 
-        kafkaProperties.put(KafkaConstants.VALUE_DELEGATE_DESERIALIZER, properties
-                .getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER));
+        if (properties.getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER) != null) {
+            kafkaProperties.put(KafkaConstants.VALUE_DELEGATE_DESERIALIZER, properties
+                    .getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER));
+        }
 
         if (properties.getProperty(KafkaConstants.VALUE_DESERIALIZER)
                 .equalsIgnoreCase(KafkaConstants.KAFKA_AVRO_DESERIALIZER)
-                || properties.getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER)
-                .equalsIgnoreCase(KafkaConstants.KAFKA_AVRO_DESERIALIZER)){
+                || KafkaConstants.KAFKA_AVRO_DESERIALIZER
+                .equalsIgnoreCase(properties.getProperty(KafkaConstants.VALUE_DELEGATE_DESERIALIZER))){
             kafkaProperties.put(KafkaConstants.SCHEMA_REGISTRY_URL, properties.
                     getProperty(KafkaConstants.SCHEMA_REGISTRY_URL, KafkaConstants.DEFAULT_SCHEMA_REGISTRY_URL));
 
@@ -699,6 +703,15 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         if (properties.getProperty(KafkaConstants.SASL_JAAS_CONFIG) != null) {
             kafkaProperties
                     .put(KafkaConstants.SASL_JAAS_CONFIG, properties.getProperty(KafkaConstants.SASL_JAAS_CONFIG));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_CLIENT_CALLBACK_HANDLER_CLASS) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+                    properties.getProperty(KafkaConstants.SASL_CLIENT_CALLBACK_HANDLER_CLASS));
+        }
+
+        if (properties.getProperty(KafkaConstants.SASL_LOGIN_CLASS) != null) {
+            kafkaProperties.put(KafkaConstants.SASL_LOGIN_CLASS, properties.getProperty(KafkaConstants.SASL_LOGIN_CLASS));
         }
 
         if (properties.getProperty(KafkaConstants.SASL_KERBEROS_SERVICE_NAME) != null) {


### PR DESCRIPTION
Adding the following new Kafka configuration properties

`sasl.client.callback.handler.class` - The fully qualified name of a SASL client callback handler class that implements the AuthenticateCallbackHandler interface.

`sasl.login.class` - The fully qualified name of a class that implements the Login interface. For brokers, login-config must be prefixed with listener prefix and SASL mechanism name in lower-case. 

Also fixes NPE issue raised in https://github.com/wso2/micro-integrator/issues/2998

