### PR TITLE
fix for enabling avro logical types

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -139,11 +139,13 @@ public class KafkaConstants {
     public static final String RECONNECT_BACKOFF_MS_DEFAULT = "50";
     public static final String RETRY_BACKOFF_MS_DEFAULT = "100";
     public static final String FAILURE_RETRY_COUNT_DEFAULT = "-1";
+    public static final String AVRO_USE_LOGICAL_TYPE_CONVERTERS = "avro.use.logical.type.converters";
 
     // Avro properties
     public static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
     public static final String SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE = "basic.auth.credentials.source";
     public static final String SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO = "basic.auth.user.info";
+    public static final String AVRO_USE_LOGICAL_TYPE_CONVERTERS_DEFAULT = "false";
 
     public static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
 

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -790,6 +790,9 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         kafkaProperties.put(KafkaConstants.RETRY_BACKOFF_MS,
                 properties.getProperty(KafkaConstants.RETRY_BACKOFF_MS, KafkaConstants.RETRY_BACKOFF_MS_DEFAULT));
 
+        kafkaProperties.put(KafkaConstants.AVRO_USE_LOGICAL_TYPE_CONVERTERS, properties
+                .getProperty(KafkaConstants.AVRO_USE_LOGICAL_TYPE_CONVERTERS, KafkaConstants.AVRO_USE_LOGICAL_TYPE_CONVERTERS_DEFAULT));
+
         if (properties.getProperty(KafkaConstants.SASL_KERBEROS_KINIT_CMD) != null) {
             kafkaProperties.put(KafkaConstants.SASL_KERBEROS_KINIT_CMD,
                     properties.getProperty(KafkaConstants.SASL_KERBEROS_KINIT_CMD));


### PR DESCRIPTION
## Purpose
The PR fixes the handling of kafka avro logical type handling.
WSO2's current implementation (v1.2.1) does not care about it. Therefore logical types like logical type decimal are currently not deserialized correctly.

## Goals
It allows to enable avro logical type handling by setting a flag in the ESB Inbound Endpoint.

## Approach
Just pass the right flag to kafka avro.

## User stories
-

## Release note
Enable avro logical type handling by setting a flag in the ESB Inbound Endpoint.
`<parameter name="avro.use.logical.type.converters">true</parameter>`

## Documentation
-

## Training
-

## Certification
N/A

## Marketing
-

## Automation tests
-

## Security checks
-

## Samples
-

## Related PRs
-

## Migrations (if applicable)
> Installed on MI 4.2 and consumed topic containing messages with logical type decimal

## Test environment
-
 
## Learning
confluent and avro documentation