### PR TITLE
Increment the retryCounter value only if the failure.retry.count is greater than 0

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -200,7 +200,9 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                                 log.error("The interval for retrying failures was interrupted while waiting.");
                             }
                         }
-                        retryCounter = retryCounter + 1;
+                        if (failureRetryCount > 0) {
+                            retryCounter = retryCounter + 1;
+                        }
                         if (retryCounter < failureRetryCount || failureRetryCount < 0) {
                             consumer.seek(topicPartition, recordOffset);
                         }
@@ -298,7 +300,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                     failureRetryCount = Integer.parseInt(properties.getProperty(KafkaConstants.FAILURE_RETRY_COUNT));
                 } catch (NumberFormatException e) {
                     log.error("Invalid input for '" + KafkaConstants.FAILURE_RETRY_COUNT
-                            + "'. The value should be a positive Integer");
+                            + "'. The value should be a valid Integer");
                 }
             } else {
                 failureRetryCount = Integer.parseInt(KafkaConstants.FAILURE_RETRY_COUNT_DEFAULT);

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -201,7 +201,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                             }
                         }
                         if (failureRetryCount > 0) {
-                            retryCounter = retryCounter + 1;
+                            retryCounter++;
                         }
                         if (retryCounter < failureRetryCount || failureRetryCount < 0) {
                             consumer.seek(topicPartition, recordOffset);


### PR DESCRIPTION
## Purpose

If the  failure.retry.count is configured to the default value -1, there can be indefinite retries to consume from the Kafka topic. In that case, the instance variable retryCounter can also be incremented to its max value. Logically, the retryCounter should only be incremented if the failure.retry.count is greater than zero. This PR fixes that issue.