### PR TITLE
Check SET_ROLLBACK_ONLY property state in operation context in case the message context got cloned during the mediation

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -476,6 +476,13 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private boolean isRollback(MessageContext msgCtx) {
         // check rollback property from synapse context
         Object rollbackProp = msgCtx.getProperty(KafkaConstants.SET_ROLLBACK_ONLY);
+        if (rollbackProp == null) {
+            // check rollback property from operation context in axis2 message context
+            org.apache.axis2.context.MessageContext axis2MessageCtx =
+                    ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+            rollbackProp = axis2MessageCtx.getOperationContext().getProperty(KafkaConstants.SET_ROLLBACK_ONLY);
+        }
+
         if (rollbackProp != null) {
             return (rollbackProp instanceof Boolean && ((Boolean) rollbackProp))
                     || (rollbackProp instanceof String && Boolean.valueOf((String) rollbackProp));


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-micro-integrator/issues/3755