### PR TITLE
Display the `Failure Retry Count` and `Failure Retry Interval` fields when the enable condition is met. 

### DIFF
--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -319,7 +319,7 @@
               "defaultValue": "5000",
               "required": "false",
               "helpTip": "Offsets are committed automatically with a frequency controlled by the config.",
-              "enableCondition": [{"enable.auto.commit":"true"}]
+              "enableCondition": [{"enable.auto.commit":true}]
             }
           },
           {
@@ -330,7 +330,7 @@
               "inputType": "string",
               "required": "false",
               "helpTip": "The maximum attempts the same Kafka message should be retried in a failure scenario.",
-              "enableCondition": [{"enable.auto.commit":"false"}]
+              "enableCondition": [{"enable.auto.commit":false}]
             }
           },
           {
@@ -341,7 +341,7 @@
               "inputType": "string",
               "required": "false",
               "helpTip": "The interval between retries in a failure scenario.",
-              "enableCondition": [{"enable.auto.commit":"false"}]
+              "enableCondition": [{"enable.auto.commit":false}]
             }
           },
           {


### PR DESCRIPTION
## Purpose
Depending on the value of the `Enable Auto Commit` field, the `Failure Retry Count` and `Failure Retry Interval` fields should be displayed. Currently, they are not appearing as expected—this PR addresses the issue.