### PR TITLE
Add MI 4.5.0 to products list

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -19,7 +19,8 @@
         {
             "tagName": "v2.0.4",
             "products": [
-                "MI 4.4.0"
+                "MI 4.4.0",
+                "MI 4.5.0"
             ],
             "operations": [
                 {
@@ -642,7 +643,8 @@
                 "MI 4.2.0",
                 "MI 4.1.0",
                 "MI 4.0.0",
-                "MI 1.2.0"
+                "MI 1.2.0",
+                "MI 4.5.0"
             ],
             "operations": [],
             "connections": [],
@@ -656,7 +658,8 @@
                 "MI 4.2.0",
                 "MI 4.1.0",
                 "MI 4.0.0",
-                "MI 1.2.0"
+                "MI 1.2.0",
+                "MI 4.5.0"
             ],
             "operations": [],
             "connections": [],


### PR DESCRIPTION
This PR adds MI 4.5.0 to the products list for releases that already contain MI 4.4.0, ensuring compatibility with the new Micro Integrator version.