### PR TITLE
Add batch mediation support for Kafka inbound endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,18 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${confluent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.commons-text</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.orbit.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.orbit.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Carbon Mediation -->
         <dependency>
             <groupId>org.wso2.carbon.mediation</groupId>
@@ -227,5 +239,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
         <carbon.mediation.version>4.4.10</carbon.mediation.version>
         <kafka.version>3.3.1</kafka.version>
         <confluent.version>7.4.0</confluent.version>
+        <commons-text.orbit.version>1.13.1.wso2v1</commons-text.orbit.version>
+        <commons-lang3.orbit.version>3.20.0.wso2v1</commons-lang3.orbit.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,25 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
         </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
@@ -136,6 +155,11 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -158,6 +158,11 @@ public class KafkaConstants {
     public static final String DEFAULT_ERROR_HANDLING_DESERIALIZER_CLASS =
             "org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer";
 
+    // Batch processing
+    public static final String BATCH_MESSAGES_ENABLED = "batch.messages.enabled";
+    public static final String BATCH_MESSAGES_ENABLED_DEFAULT = "false";
+    public static final String KAFKA_BATCH_SIZE = "batchSize";
+
     // Error codes
     public static final String POISON_PILL_DETECTED = "700510";
     public static final String RETRY_EXHAUSTED = "700511";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -161,8 +161,6 @@ public class KafkaConstants {
     // Batch processing
     public static final String BATCH_PROCESSING_ENABLED = "batch.processing.enabled";
     public static final String BATCH_PROCESSING_ENABLED_DEFAULT = "false";
-    public static final String KAFKA_BATCH_SIZE = "batchSize";
-
     // Error codes
     public static final String POISON_PILL_DETECTED = "700510";
     public static final String RETRY_EXHAUSTED = "700511";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -165,13 +165,28 @@ public class KafkaConstants {
     // Dead Letter Queue (DLQ) configuration
     public static final String DLQ_TOPIC = "kafka.dlq.topic";
 
-    // DLT provenance headers 
+    // DLT provenance headers
     public static final String DLT_ORIGINAL_TOPIC = "kafka_dlt-original-topic";
     public static final String DLT_ORIGINAL_PARTITION = "kafka_dlt-original-partition";
     public static final String DLT_ORIGINAL_OFFSET = "kafka_dlt-original-offset";
     public static final String DLT_ORIGINAL_TIMESTAMP = "kafka_dlt-original-timestamp";
     public static final String DLT_EXCEPTION_MESSAGE = "kafka_dlt-exception-message";
     public static final String DLT_EXCEPTION_CAUSE_MESSAGE = "kafka_dlt-exception-cause-message";
+    
+    public static final String BYTE_ARRAY_SERIALIZER_CLASS =
+            "org.apache.kafka.common.serialization.ByteArraySerializer";
+
+    // Batch payload content types
+    public static final String CONTENT_TYPE_APPLICATION_XML = "application/xml";
+    public static final String CONTENT_TYPE_TEXT_XML = "text/xml";
+    public static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+
+    // Batch payload XML templates
+    public static final String BATCH_XML_ROOT_START_TAG = "<messages>";
+    public static final String BATCH_XML_ROOT_END_TAG = "</messages>";
+    public static final String BATCH_TEXT_ELEMENT_START_TAG =
+            "<text xmlns=\"http://ws.apache.org/commons/ns/payload\">";
+    public static final String BATCH_TEXT_ELEMENT_END_TAG = "</text>";
 
     // Error codes
     public static final String POISON_PILL_DETECTED = "700510";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -159,8 +159,8 @@ public class KafkaConstants {
             "org.wso2.carbon.inbound.kafka.deserializer.ErrorHandlingDeserializer";
 
     // Batch processing
-    public static final String BATCH_MESSAGES_ENABLED = "batch.messages.enabled";
-    public static final String BATCH_MESSAGES_ENABLED_DEFAULT = "false";
+    public static final String BATCH_PROCESSING_ENABLED = "batch.processing.enabled";
+    public static final String BATCH_PROCESSING_ENABLED_DEFAULT = "false";
     public static final String KAFKA_BATCH_SIZE = "batchSize";
 
     // Error codes

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -161,6 +161,18 @@ public class KafkaConstants {
     // Batch processing
     public static final String BATCH_PROCESSING_ENABLED = "batch.processing.enabled";
     public static final String BATCH_PROCESSING_ENABLED_DEFAULT = "false";
+
+    // Dead Letter Queue (DLQ) configuration
+    public static final String DLQ_TOPIC = "kafka.dlq.topic";
+
+    // DLT provenance headers 
+    public static final String DLT_ORIGINAL_TOPIC = "kafka_dlt-original-topic";
+    public static final String DLT_ORIGINAL_PARTITION = "kafka_dlt-original-partition";
+    public static final String DLT_ORIGINAL_OFFSET = "kafka_dlt-original-offset";
+    public static final String DLT_ORIGINAL_TIMESTAMP = "kafka_dlt-original-timestamp";
+    public static final String DLT_EXCEPTION_MESSAGE = "kafka_dlt-exception-message";
+    public static final String DLT_EXCEPTION_CAUSE_MESSAGE = "kafka_dlt-exception-cause-message";
+
     // Error codes
     public static final String POISON_PILL_DETECTED = "700510";
     public static final String RETRY_EXHAUSTED = "700511";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -79,7 +79,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
     private static final Log log = LogFactory.getLog(KafkaMessageConsumer.class);
 
-
     private KafkaConsumer<byte[], byte[]> consumer;
 
     private String bootstrapServersName;
@@ -426,10 +425,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
      */
     private String buildBatchPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         String type = contentType != null ? contentType.split(";")[0].trim() : "";
-        if ("application/xml".equalsIgnoreCase(type) || "text/xml".equalsIgnoreCase(type)) {
+        if (KafkaConstants.CONTENT_TYPE_APPLICATION_XML.equalsIgnoreCase(type)
+                || KafkaConstants.CONTENT_TYPE_TEXT_XML.equalsIgnoreCase(type)) {
             return buildBatchXmlPayload(records);
         }
-        if ("application/json".equalsIgnoreCase(type)) {
+        if (KafkaConstants.CONTENT_TYPE_APPLICATION_JSON.equalsIgnoreCase(type)) {
             return buildBatchJsonPayload(records);
         }
         return buildBatchTextPayload(records);
@@ -437,20 +437,20 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
     private String getBatchContentType() {
         String type = contentType != null ? contentType.split(";")[0].trim() : "";
-        if ("application/json".equalsIgnoreCase(type)) {
+        if (KafkaConstants.CONTENT_TYPE_APPLICATION_JSON.equalsIgnoreCase(type)) {
             return contentType;
         }
-        return "application/xml";
+        return KafkaConstants.CONTENT_TYPE_APPLICATION_XML;
     }
 
     private String buildBatchTextPayload(List<ConsumerRecord<byte[], byte[]>> records) {
-        StringBuilder sb = new StringBuilder("<messages>");
+        StringBuilder sb = new StringBuilder(KafkaConstants.BATCH_XML_ROOT_START_TAG);
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            sb.append("<text xmlns=\"http://ws.apache.org/commons/ns/payload\">")
+            sb.append(KafkaConstants.BATCH_TEXT_ELEMENT_START_TAG)
                     .append(StringEscapeUtils.escapeXml10(recordValueToString(record.value())))
-                    .append("</text>");
+                    .append(KafkaConstants.BATCH_TEXT_ELEMENT_END_TAG);
         }
-        sb.append("</messages>");
+        sb.append(KafkaConstants.BATCH_XML_ROOT_END_TAG);
         return sb.toString();
     }
 
@@ -467,11 +467,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     }
 
     private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
-        StringBuilder sb = new StringBuilder("<messages>");
+        StringBuilder sb = new StringBuilder(KafkaConstants.BATCH_XML_ROOT_START_TAG);
         for (ConsumerRecord<byte[], byte[]> record : records) {
             sb.append(recordValueToString(record.value()));
         }
-        sb.append("</messages>");
+        sb.append(KafkaConstants.BATCH_XML_ROOT_END_TAG);
         return sb.toString();
     }
 
@@ -549,9 +549,9 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 .filter(ProducerConfig.configNames()::contains)
                 .forEach(key -> producerProps.put(key, kafkaProperties.getProperty(key)));
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.ByteArraySerializer");
+                KafkaConstants.BYTE_ARRAY_SERIALIZER_CLASS);
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.ByteArraySerializer");
+                KafkaConstants.BYTE_ARRAY_SERIALIZER_CLASS);
         return new KafkaProducer<>(producerProps);
     }
 

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -612,8 +612,8 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private void populateOtherProperties(Properties properties) {
         checkDisableAutoCommit(properties);
         isBatchEnabled = Boolean.parseBoolean(
-                properties.getProperty(KafkaConstants.BATCH_MESSAGES_ENABLED,
-                        KafkaConstants.BATCH_MESSAGES_ENABLED_DEFAULT));
+                properties.getProperty(KafkaConstants.BATCH_PROCESSING_ENABLED,
+                        KafkaConstants.BATCH_PROCESSING_ENABLED_DEFAULT));
         if (properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX) != null) {
             kafkaHeaderPrefix = properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX).trim();
         }

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -481,10 +481,9 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 sb.append(",");
             }
             sb.append("{");
+            sb.append("\"topic\":\"").append(escapeJson(record.topic())).append("\",");
             sb.append("\"partition\":").append(record.partition()).append(",");
             sb.append("\"offset\":").append(record.offset()).append(",");
-            sb.append("\"timestamp\":").append(record.timestamp()).append(",");
-            sb.append("\"topic\":\"").append(escapeJson(record.topic())).append("\",");
             Object key = record.key();
             if (key == null) {
                 sb.append("\"key\":null,");

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -312,8 +312,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         }
 
         List<ConsumerRecord<byte[], byte[]>> validRecords = new ArrayList<>();
-        List<ConsumerRecord<byte[], byte[]>> poisonPillRecords = new ArrayList<>();
-        List<String> poisonPillErrors = new ArrayList<>();
         Map<TopicPartition, Long> firstOffsets = new HashMap<>();
         Map<TopicPartition, Long> lastOffsets = new HashMap<>();
 
@@ -325,10 +323,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                         log.warn("A poison pill was detected in batch for Topic: " + record.topic()
                                 + ", Partition No: " + record.partition()
                                 + ", Offset: " + record.offset()
-                                + ". Error details will be included in the batch injected to the `onError` sequence: "
-                                + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name);
-                        poisonPillRecords.add(record);
-                        poisonPillErrors.add(extractPoisonPillError(record));
+                                + " of Kafka Inbound Endpoint: " + name + ". The record will be skipped.");
                     } else {
                         log.warn("A null record was passed and skipped in batch for Topic: " + record.topic()
                                 + ", Partition No: " + record.partition()
@@ -339,10 +334,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                     validRecords.add(record);
                 }
             }
-        }
-
-        if (!poisonPillRecords.isEmpty()) {
-            injectBatchPoisonPills(poisonPillRecords, poisonPillErrors);
         }
 
         if (validRecords.isEmpty()) {
@@ -394,106 +385,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 }
             }
         }
-    }
-
-    /**
-     * Deserialize and return the error message from a poison pill record's exception header.
-     */
-    private String extractPoisonPillError(ConsumerRecord<byte[], byte[]> record) {
-        Header keyHeader = record.headers().lastHeader(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER);
-        Header valueHeader = record.headers().lastHeader(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER);
-        byte[] headerValue = keyHeader != null ? keyHeader.value() : valueHeader.value();
-        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(headerValue))) {
-            return ((KafkaException) ois.readObject()).getMessage();
-        } catch (ClassNotFoundException | IOException e) {
-            log.error("Could not deserialize the poison pill exception header for Kafka Inbound Endpoint: "
-                    + name, e);
-            return "Unknown deserialization error";
-        }
-    }
-
-    /**
-     * Build a JSON array from the poison pill records and their extracted error messages, then
-     * inject once to the configured onError sequence with ERROR_CODE and ERROR_MESSAGE properties.
-     */
-    private void injectBatchPoisonPills(List<ConsumerRecord<byte[], byte[]>> poisonPillRecords,
-                                        List<String> errorMessages) {
-        if (StringUtils.isEmpty(this.onErrorSeq)) {
-            log.error("Could not mediate batch poison pill errors as the 'onError' sequence name is not "
-                    + "specified for Kafka Inbound Endpoint: " + name);
-            return;
-        }
-        SequenceMediator errorSeq = (SequenceMediator) this.synapseEnvironment.getSynapseConfiguration()
-                .getSequence(this.onErrorSeq);
-        if (errorSeq == null) {
-            log.error("Could not mediate batch poison pill errors as the 'onError' sequence with name: "
-                    + this.onErrorSeq + " not found for Kafka Inbound Endpoint: " + name);
-            return;
-        }
-
-        MessageContext msgCtx = createMessageContext();
-        msgCtx.setProperty(KafkaConstants.KAFKA_INBOUND_ENDPOINT_NAME, name);
-        msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
-        msgCtx.setProperty(SynapseConstants.ERROR_CODE, KafkaConstants.POISON_PILL_DETECTED);
-        msgCtx.setProperty(SynapseConstants.ERROR_MESSAGE, poisonPillRecords.size()
-                + " poison pill(s) detected in batch of Kafka Inbound Endpoint: " + name);
-
-        try {
-            String payload = buildPoisonPillBatchPayload(poisonPillRecords, errorMessages);
-            org.apache.axis2.context.MessageContext axis2MsgCtx =
-                    ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
-            Builder builder = (Builder) BuilderUtil.getBuilderFromSelector("application/json", axis2MsgCtx);
-            if (builder == null) {
-                builder = new SOAPBuilder();
-            }
-            OMElement documentElement = builder.processDocument(
-                    new AutoCloseInputStream(new ByteArrayInputStream(payload.getBytes())),
-                    "application/json", axis2MsgCtx);
-            msgCtx.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));
-        } catch (Exception e) {
-            log.error("Error while building batch poison pill payload for 'onError' sequence: "
-                    + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name, e);
-            return;
-        }
-
-        if (log.isDebugEnabled()) {
-            log.debug("Injecting batch of " + poisonPillRecords.size()
-                    + " poison pill(s) to 'onError' sequence: " + this.onErrorSeq
-                    + " of Kafka Inbound Endpoint: " + name);
-        }
-        if (!this.synapseEnvironment.injectInbound(msgCtx, errorSeq, this.sequential)) {
-            log.warn("Could not inject the batch poison pill details to 'onError' sequence: "
-                    + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name);
-        }
-    }
-
-    /**
-     * Build a JSON array where each element contains the record metadata and its deserialization
-     * error message.
-     */
-    private String buildPoisonPillBatchPayload(List<ConsumerRecord<byte[], byte[]>> records,
-                                               List<String> errorMessages) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < records.size(); i++) {
-            ConsumerRecord<byte[], byte[]> record = records.get(i);
-            if (i > 0) {
-                sb.append(",");
-            }
-            sb.append("{");
-            sb.append("\"topic\":\"").append(escapeJson(record.topic())).append("\",");
-            sb.append("\"partition\":").append(record.partition()).append(",");
-            sb.append("\"offset\":").append(record.offset()).append(",");
-            Object key = record.key();
-            if (key == null) {
-                sb.append("\"key\":null,");
-            } else {
-                sb.append("\"key\":\"").append(escapeJson(key.toString())).append("\",");
-            }
-            sb.append("\"errorMessage\":\"").append(escapeJson(errorMessages.get(i))).append("\"");
-            sb.append("}");
-        }
-        sb.append("]");
-        return sb.toString();
     }
 
     /**
@@ -569,17 +460,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         return input.replace("&", "&amp;")
                 .replace("<", "&lt;")
                 .replace(">", "&gt;");
-    }
-
-    private String escapeJson(String input) {
-        if (input == null) {
-            return "";
-        }
-        return input.replace("\\", "\\\\")
-                .replace("\"", "\\\"")
-                .replace("\n", "\\n")
-                .replace("\r", "\\r")
-                .replace("\t", "\\t");
     }
 
     private MessageContext createBatchMessageContext() {

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -613,7 +613,13 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             return null;
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(exceptionHeader.value()))) {
-            return (DeserializationException) ois.readObject();
+            Object obj = ois.readObject();
+            if (obj instanceof DeserializationException) {
+                return (DeserializationException) obj;
+            }
+            log.warn("Unexpected type in deserialization exception header: " + obj.getClass().getName()
+                    + " for topic=" + record.topic() + " offset=" + record.offset());
+            return null;
         } catch (Exception e) {
             log.warn("Could not read deserialization exception from poison pill header for topic="
                     + record.topic() + " offset=" + record.offset(), e);

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -583,17 +583,18 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         ProducerRecord<byte[], byte[]> dlqRecord = new ProducerRecord<>(
                 dlqTopic, null, record.key(), originalBytes, dlqHeaders);
 
-        try {
-            dlqProducer.send(dlqRecord).get();
-            log.info("Poison pill published to DLQ topic=" + dlqTopic
-                    + " from source topic=" + record.topic()
-                    + " partition=" + record.partition()
-                    + " offset=" + record.offset());
-        } catch (Exception e) {
-            log.error("Failed to publish poison pill to DLQ topic=" + dlqTopic
-                    + " from source topic=" + record.topic()
-                    + " offset=" + record.offset(), e);
-        }
+        dlqProducer.send(dlqRecord, (metadata, exception) -> {
+            if (exception != null) {
+                log.error("Failed to publish poison pill to DLQ topic=" + dlqTopic
+                        + " from source topic=" + record.topic()
+                        + " offset=" + record.offset(), exception);
+            } else {
+                log.info("Poison pill published to DLQ topic=" + dlqTopic
+                        + " from source topic=" + record.topic()
+                        + " partition=" + record.partition()
+                        + " offset=" + record.offset());
+            }
+        });
     }
 
     /**

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -358,7 +358,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         }
 
         MessageContext msgCtx = createBatchMessageContext(validRecords.size());
-        boolean isConsumed = injectMessage(buildBatchPayload(validRecords), "application/json", msgCtx);
+        boolean isConsumed = injectMessage(buildBatchPayload(validRecords), getBatchContentType(), msgCtx);
 
         if (isDisableAutoCommit) {
             if (isConsumed) {
@@ -513,10 +513,38 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
      * matching the payload format used in single-record mode.
      */
     private String buildBatchPayload(List<ConsumerRecord<byte[], byte[]>> records) {
+        String type = contentType != null ? contentType.split(";")[0].trim() : "";
+        if ("application/xml".equalsIgnoreCase(type) || "text/xml".equalsIgnoreCase(type)) {
+            return buildBatchXmlPayload(records);
+        }
+        if ("text/plain".equalsIgnoreCase(type)) {
+            return buildBatchTextPayload(records);
+        }
+        return buildBatchJsonPayload(records);
+    }
+
+    private String getBatchContentType() {
+        String type = contentType != null ? contentType.split(";")[0].trim() : "";
+        if ("text/plain".equalsIgnoreCase(type)) {
+            return "application/xml";
+        }
+        return contentType;
+    }
+
+    private String buildBatchTextPayload(List<ConsumerRecord<byte[], byte[]>> records) {
+        StringBuilder sb = new StringBuilder("<messages>");
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            sb.append("<text xmlns=\"http://ws.apache.org/commons/ns/payload\">")
+                    .append(escapeXml(deserializedToString(record.value())))
+                    .append("</text>");
+        }
+        sb.append("</messages>");
+        return sb.toString();
+    }
+
+    private String buildBatchJsonPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < records.size(); i++) {
-            // Access via raw type to avoid compiler-inserted checkcast when the configured
-            // deserializer returns a type other than byte[] (e.g. StringDeserializer).
             @SuppressWarnings("rawtypes")
             ConsumerRecord rawRecord = records.get(i);
             if (i > 0) {
@@ -528,11 +556,33 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         return sb.toString();
     }
 
+    private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
+        StringBuilder sb = new StringBuilder("<messages>");
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            @SuppressWarnings("rawtypes")
+            ConsumerRecord rawRecord = (ConsumerRecord) record;
+            sb.append(escapeXml(deserializedToString(rawRecord.value())));
+        }
+        sb.append("</messages>");
+        return sb.toString();
+    }
+
     private String deserializedToString(Object value) {
         if (value instanceof byte[]) {
             return new String((byte[]) value, StandardCharsets.UTF_8);
         }
         return String.valueOf(value);
+    }
+
+    private String escapeXml(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
     }
 
     private String escapeJson(String input) {

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -510,34 +510,20 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     }
 
     /**
-     * Build a JSON array string from the given records. Each element contains
-     * partition, offset, timestamp, topic, key, and value fields.
+     * Build a JSON array string from the given records. Each element is the raw record value,
+     * matching the payload format used in single-record mode.
      */
     private String buildBatchPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < records.size(); i++) {
-            ConsumerRecord<byte[], byte[]> record = records.get(i);
-            if (i > 0) {
-                sb.append(",");
-            }
-            sb.append("{");
-            sb.append("\"partition\":").append(record.partition()).append(",");
-            sb.append("\"offset\":").append(record.offset()).append(",");
-            sb.append("\"timestamp\":").append(record.timestamp()).append(",");
-            sb.append("\"topic\":\"").append(escapeJson(record.topic())).append("\",");
             // Access via raw type to avoid compiler-inserted checkcast when the configured
             // deserializer returns a type other than byte[] (e.g. StringDeserializer).
             @SuppressWarnings("rawtypes")
-            ConsumerRecord rawRecord = record;
-            Object key = rawRecord.key();
-            Object value = rawRecord.value();
-            if (key == null) {
-                sb.append("\"key\":null,");
-            } else {
-                sb.append("\"key\":\"").append(escapeJson(deserializedToString(key))).append("\",");
+            ConsumerRecord rawRecord = records.get(i);
+            if (i > 0) {
+                sb.append(",");
             }
-            sb.append("\"value\":\"").append(escapeJson(deserializedToString(value))).append("\"");
-            sb.append("}");
+            sb.append(deserializedToString(rawRecord.value()));
         }
         sb.append("]");
         return sb.toString();

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -498,7 +498,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             kafkaHeaderPrefix = properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX).trim();
         }
         dlqTopic = properties.getProperty(KafkaConstants.DLQ_TOPIC);
-        if (!StringUtils.isEmpty(dlqTopic)) {
+        if (isBatchEnabled && !StringUtils.isEmpty(dlqTopic)) {
             dlqProducer = initDlqProducer();
             log.info("DLQ producer initialized for Kafka Inbound Endpoint: " + name
                     + ". Poison pills will be published to topic: " + dlqTopic);

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -357,7 +357,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                     + " Endpoint: " + name);
         }
 
-        MessageContext msgCtx = createBatchMessageContext(validRecords.size());
+        MessageContext msgCtx = createBatchMessageContext();
         boolean isConsumed = injectMessage(buildBatchPayload(validRecords), getBatchContentType(), msgCtx);
 
         if (isDisableAutoCommit) {
@@ -534,7 +534,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
             sb.append("<text xmlns=\"http://ws.apache.org/commons/ns/payload\">")
-                    .append(escapeXml(deserializedToString(record.value())))
+                    .append(escapeXml(new String(record.value(), StandardCharsets.UTF_8)))
                     .append("</text>");
         }
         sb.append("</messages>");
@@ -547,7 +547,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             if (i > 0) {
                 sb.append(",");
             }
-            sb.append(deserializedToString(records.get(i).value()));
+            sb.append(new String(records.get(i).value(), StandardCharsets.UTF_8));
         }
         sb.append("]");
         return sb.toString();
@@ -556,17 +556,10 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            sb.append(escapeXml(deserializedToString(record.value())));
+            sb.append(escapeXml(new String(record.value(), StandardCharsets.UTF_8)));
         }
         sb.append("</messages>");
         return sb.toString();
-    }
-
-    private String deserializedToString(Object value) {
-        if (value instanceof byte[]) {
-            return new String((byte[]) value, StandardCharsets.UTF_8);
-        }
-        return String.valueOf(value);
     }
 
     private String escapeXml(String input) {
@@ -591,9 +584,8 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 .replace("\t", "\\t");
     }
 
-    private MessageContext createBatchMessageContext(int batchSize) {
+    private MessageContext createBatchMessageContext() {
         MessageContext msgCtx = createMessageContext();
-        msgCtx.setProperty(KafkaConstants.KAFKA_BATCH_SIZE, batchSize);
         msgCtx.setProperty(KafkaConstants.KAFKA_INBOUND_ENDPOINT_NAME, name);
         msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
         return msgCtx;

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -432,7 +432,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         }
 
         MessageContext msgCtx = createMessageContext();
-        msgCtx.setProperty(KafkaConstants.KAFKA_BATCH_SIZE, poisonPillRecords.size());
         msgCtx.setProperty(KafkaConstants.KAFKA_INBOUND_ENDPOINT_NAME, name);
         msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
         msgCtx.setProperty(SynapseConstants.ERROR_CODE, KafkaConstants.POISON_PILL_DETECTED);
@@ -545,12 +544,10 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private String buildBatchJsonPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < records.size(); i++) {
-            @SuppressWarnings("rawtypes")
-            ConsumerRecord rawRecord = records.get(i);
             if (i > 0) {
                 sb.append(",");
             }
-            sb.append(deserializedToString(rawRecord.value()));
+            sb.append(deserializedToString(records.get(i).value()));
         }
         sb.append("]");
         return sb.toString();
@@ -559,9 +556,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            @SuppressWarnings("rawtypes")
-            ConsumerRecord rawRecord = (ConsumerRecord) record;
-            sb.append(escapeXml(deserializedToString(rawRecord.value())));
+            sb.append(escapeXml(deserializedToString(record.value())));
         }
         sb.append("</messages>");
         return sb.toString();

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -25,6 +25,7 @@ import org.apache.axis2.builder.SOAPBuilder;
 import org.apache.axis2.transport.TransportUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -433,7 +434,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
             sb.append("<text xmlns=\"http://ws.apache.org/commons/ns/payload\">")
-                    .append(escapeXml(recordValueToString(record.value())))
+                    .append(StringEscapeUtils.escapeXml10(recordValueToString(record.value())))
                     .append("</text>");
         }
         sb.append("</messages>");
@@ -466,15 +467,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             return new String((byte[]) value, StandardCharsets.UTF_8);
         }
         return value.toString();
-    }
-
-    private String escapeXml(String input) {
-        if (input == null) {
-            return "";
-        }
-        return input.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
     }
 
     private MessageContext createBatchMessageContext() {

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -50,12 +50,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -81,6 +84,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private Properties kafkaProperties;
     private boolean isRegexPattern = false;
     private boolean isDisableAutoCommit;
+    private boolean isBatchEnabled = false;
     private int failureRetryCount;
     private int retryCounter = 0;
     private long failureRetryInterval = -1;
@@ -115,7 +119,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
             ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.of(Long.parseLong(pollTimeout),
                     ChronoUnit.MILLIS));
-            commitRecords(records);
+            if (isBatchEnabled) {
+                commitRecordsAsBatch(records);
+            } else {
+                commitRecords(records);
+            }
         } catch (WakeupException ex) {
             log.error("Error while wakeup the consumer " + consumer);
             consumer.close();
@@ -290,12 +298,287 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     }
 
     /**
+     * Inject all records from a single poll as a single JSON array message to the insequence.
+     * Poison pills and null-value records are skipped individually before the batch is assembled.
+     * With manual commit (enable.auto.commit=false), the entire batch is committed on success or
+     * seeked back to each partition's first offset on failure; retry logic mirrors the per-record
+     * behaviour.
+     *
+     * @param records ConsumerRecords from a single poll
+     */
+    private void commitRecordsAsBatch(ConsumerRecords<byte[], byte[]> records) {
+        if (records.isEmpty()) {
+            return;
+        }
+
+        List<ConsumerRecord<byte[], byte[]>> validRecords = new ArrayList<>();
+        List<ConsumerRecord<byte[], byte[]>> poisonPillRecords = new ArrayList<>();
+        List<String> poisonPillErrors = new ArrayList<>();
+        Map<TopicPartition, Long> firstOffsets = new HashMap<>();
+        Map<TopicPartition, Long> lastOffsets = new HashMap<>();
+
+        for (TopicPartition partition : records.partitions()) {
+            for (ConsumerRecord<byte[], byte[]> record : records.records(partition)) {
+                lastOffsets.put(partition, record.offset());
+                if (record.value() == null) {
+                    if (isPoisonPill(record)) {
+                        log.warn("A poison pill was detected in batch for Topic: " + record.topic()
+                                + ", Partition No: " + record.partition()
+                                + ", Offset: " + record.offset()
+                                + ". Error details will be included in the batch injected to the `onError` sequence: "
+                                + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name);
+                        poisonPillRecords.add(record);
+                        poisonPillErrors.add(extractPoisonPillError(record));
+                    } else {
+                        log.warn("A null record was passed and skipped in batch for Topic: " + record.topic()
+                                + ", Partition No: " + record.partition()
+                                + ", Offset: " + record.offset());
+                    }
+                } else {
+                    firstOffsets.putIfAbsent(partition, record.offset());
+                    validRecords.add(record);
+                }
+            }
+        }
+
+        if (!poisonPillRecords.isEmpty()) {
+            injectBatchPoisonPills(poisonPillRecords, poisonPillErrors);
+        }
+
+        if (validRecords.isEmpty()) {
+            if (isDisableAutoCommit) {
+                commitOffsets(lastOffsets, 1);
+            }
+            return;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Injecting a batch of " + validRecords.size() + " Kafka messages for inbound mediation."
+                    + " Endpoint: " + name);
+        }
+
+        MessageContext msgCtx = createBatchMessageContext(validRecords.size());
+        boolean isConsumed = injectMessage(buildBatchPayload(validRecords), "application/json", msgCtx);
+
+        if (isDisableAutoCommit) {
+            if (isConsumed) {
+                retryCounter = 0;
+                commitOffsets(lastOffsets, 1);
+            } else {
+                if (failureRetryInterval > 0 && (retryCounter < failureRetryCount || failureRetryCount < 0)) {
+                    try {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Failed Kafka batch will be retried after max(poll_interval,"
+                                    + " failure_retry_interval): "
+                                    + Long.max(failureRetryInterval, scanInterval) + "ms.");
+                        }
+                        Thread.sleep(this.failureRetryInterval);
+                    } catch (InterruptedException e) {
+                        log.error("The interval for retrying batch failures was interrupted while waiting.");
+                    }
+                }
+                if (failureRetryCount > 0) {
+                    retryCounter++;
+                }
+                if (retryCounter < failureRetryCount || failureRetryCount < 0) {
+                    for (Map.Entry<TopicPartition, Long> entry : firstOffsets.entrySet()) {
+                        consumer.seek(entry.getKey(), entry.getValue());
+                    }
+                } else {
+                    log.warn("The batch offset set to the next record since failure retry count exceeded.");
+                    commitOffsets(lastOffsets, 1);
+                    retryCounter = 0;
+                    injectErrorMessage("Failed to successfully mediate the batch message to/in the sequence: "
+                            + this.injectingSeq + " of Kafka Inbound Endpoint: " + name + ", even after "
+                            + failureRetryCount + " retries.", KafkaConstants.RETRY_EXHAUSTED, msgCtx);
+                }
+            }
+        }
+    }
+
+    /**
+     * Deserialize and return the error message from a poison pill record's exception header.
+     */
+    private String extractPoisonPillError(ConsumerRecord<byte[], byte[]> record) {
+        Header keyHeader = record.headers().lastHeader(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER);
+        Header valueHeader = record.headers().lastHeader(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+        byte[] headerValue = keyHeader != null ? keyHeader.value() : valueHeader.value();
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(headerValue))) {
+            return ((KafkaException) ois.readObject()).getMessage();
+        } catch (ClassNotFoundException | IOException e) {
+            log.error("Could not deserialize the poison pill exception header for Kafka Inbound Endpoint: "
+                    + name, e);
+            return "Unknown deserialization error";
+        }
+    }
+
+    /**
+     * Build a JSON array from the poison pill records and their extracted error messages, then
+     * inject once to the configured onError sequence with ERROR_CODE and ERROR_MESSAGE properties.
+     */
+    private void injectBatchPoisonPills(List<ConsumerRecord<byte[], byte[]>> poisonPillRecords,
+                                        List<String> errorMessages) {
+        if (StringUtils.isEmpty(this.onErrorSeq)) {
+            log.error("Could not mediate batch poison pill errors as the 'onError' sequence name is not "
+                    + "specified for Kafka Inbound Endpoint: " + name);
+            return;
+        }
+        SequenceMediator errorSeq = (SequenceMediator) this.synapseEnvironment.getSynapseConfiguration()
+                .getSequence(this.onErrorSeq);
+        if (errorSeq == null) {
+            log.error("Could not mediate batch poison pill errors as the 'onError' sequence with name: "
+                    + this.onErrorSeq + " not found for Kafka Inbound Endpoint: " + name);
+            return;
+        }
+
+        MessageContext msgCtx = createMessageContext();
+        msgCtx.setProperty(KafkaConstants.KAFKA_BATCH_SIZE, poisonPillRecords.size());
+        msgCtx.setProperty(KafkaConstants.KAFKA_INBOUND_ENDPOINT_NAME, name);
+        msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
+        msgCtx.setProperty(SynapseConstants.ERROR_CODE, KafkaConstants.POISON_PILL_DETECTED);
+        msgCtx.setProperty(SynapseConstants.ERROR_MESSAGE, poisonPillRecords.size()
+                + " poison pill(s) detected in batch of Kafka Inbound Endpoint: " + name);
+
+        try {
+            String payload = buildPoisonPillBatchPayload(poisonPillRecords, errorMessages);
+            org.apache.axis2.context.MessageContext axis2MsgCtx =
+                    ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+            Builder builder = (Builder) BuilderUtil.getBuilderFromSelector("application/json", axis2MsgCtx);
+            if (builder == null) {
+                builder = new SOAPBuilder();
+            }
+            OMElement documentElement = builder.processDocument(
+                    new AutoCloseInputStream(new ByteArrayInputStream(payload.getBytes())),
+                    "application/json", axis2MsgCtx);
+            msgCtx.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));
+        } catch (Exception e) {
+            log.error("Error while building batch poison pill payload for 'onError' sequence: "
+                    + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name, e);
+            return;
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Injecting batch of " + poisonPillRecords.size()
+                    + " poison pill(s) to 'onError' sequence: " + this.onErrorSeq
+                    + " of Kafka Inbound Endpoint: " + name);
+        }
+        if (!this.synapseEnvironment.injectInbound(msgCtx, errorSeq, this.sequential)) {
+            log.warn("Could not inject the batch poison pill details to 'onError' sequence: "
+                    + this.onErrorSeq + " of Kafka Inbound Endpoint: " + name);
+        }
+    }
+
+    /**
+     * Build a JSON array where each element contains the record metadata and its deserialization
+     * error message.
+     */
+    private String buildPoisonPillBatchPayload(List<ConsumerRecord<byte[], byte[]>> records,
+                                               List<String> errorMessages) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < records.size(); i++) {
+            ConsumerRecord<byte[], byte[]> record = records.get(i);
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("{");
+            sb.append("\"partition\":").append(record.partition()).append(",");
+            sb.append("\"offset\":").append(record.offset()).append(",");
+            sb.append("\"timestamp\":").append(record.timestamp()).append(",");
+            sb.append("\"topic\":\"").append(escapeJson(record.topic())).append("\",");
+            Object key = record.key();
+            if (key == null) {
+                sb.append("\"key\":null,");
+            } else {
+                sb.append("\"key\":\"").append(escapeJson(key.toString())).append("\",");
+            }
+            sb.append("\"errorMessage\":\"").append(escapeJson(errorMessages.get(i))).append("\"");
+            sb.append("}");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    /**
+     * Commit the given per-partition offsets adjusted by the provided delta.
+     */
+    private void commitOffsets(Map<TopicPartition, Long> offsets, long delta) {
+        Map<TopicPartition, OffsetAndMetadata> commitMap = new HashMap<>();
+        for (Map.Entry<TopicPartition, Long> entry : offsets.entrySet()) {
+            commitMap.put(entry.getKey(), new OffsetAndMetadata(entry.getValue() + delta));
+        }
+        consumer.commitSync(commitMap);
+    }
+
+    /**
+     * Build a JSON array string from the given records. Each element contains
+     * partition, offset, timestamp, topic, key, and value fields.
+     */
+    private String buildBatchPayload(List<ConsumerRecord<byte[], byte[]>> records) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < records.size(); i++) {
+            ConsumerRecord<byte[], byte[]> record = records.get(i);
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("{");
+            sb.append("\"partition\":").append(record.partition()).append(",");
+            sb.append("\"offset\":").append(record.offset()).append(",");
+            sb.append("\"timestamp\":").append(record.timestamp()).append(",");
+            sb.append("\"topic\":\"").append(escapeJson(record.topic())).append("\",");
+            // Access via raw type to avoid compiler-inserted checkcast when the configured
+            // deserializer returns a type other than byte[] (e.g. StringDeserializer).
+            @SuppressWarnings("rawtypes")
+            ConsumerRecord rawRecord = record;
+            Object key = rawRecord.key();
+            Object value = rawRecord.value();
+            if (key == null) {
+                sb.append("\"key\":null,");
+            } else {
+                sb.append("\"key\":\"").append(escapeJson(deserializedToString(key))).append("\",");
+            }
+            sb.append("\"value\":\"").append(escapeJson(deserializedToString(value))).append("\"");
+            sb.append("}");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private String deserializedToString(Object value) {
+        if (value instanceof byte[]) {
+            return new String((byte[]) value, StandardCharsets.UTF_8);
+        }
+        return String.valueOf(value);
+    }
+
+    private String escapeJson(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    private MessageContext createBatchMessageContext(int batchSize) {
+        MessageContext msgCtx = createMessageContext();
+        msgCtx.setProperty(KafkaConstants.KAFKA_BATCH_SIZE, batchSize);
+        msgCtx.setProperty(KafkaConstants.KAFKA_INBOUND_ENDPOINT_NAME, name);
+        msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
+        return msgCtx;
+    }
+
+    /**
      * Populate properties that are related to the functionality of Kafka Inbound Endpoint feature.
      *
      * @param properties properties configured in the Kafka Inbound Endpoint
      */
     private void populateOtherProperties(Properties properties) {
         checkDisableAutoCommit(properties);
+        isBatchEnabled = Boolean.parseBoolean(
+                properties.getProperty(KafkaConstants.BATCH_MESSAGES_ENABLED,
+                        KafkaConstants.BATCH_MESSAGES_ENABLED_DEFAULT));
         if (properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX) != null) {
             kafkaHeaderPrefix = properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX).trim();
         }

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -322,12 +322,12 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         }
 
         List<ConsumerRecord<byte[], byte[]>> validRecords = new ArrayList<>();
-        Map<TopicPartition, Long> firstOffsets = new HashMap<>();
-        Map<TopicPartition, Long> lastOffsets = new HashMap<>();
+        Map<TopicPartition, Long> firstValidOffsetsByPartition = new HashMap<>();
+        Map<TopicPartition, Long> lastPolledOffsetsByPartition = new HashMap<>();
 
         for (TopicPartition partition : records.partitions()) {
             for (ConsumerRecord<byte[], byte[]> record : records.records(partition)) {
-                lastOffsets.put(partition, record.offset());
+                lastPolledOffsetsByPartition.put(partition, record.offset());
                 if (record.value() == null) {
                     if (isPoisonPill(record)) {
                         TopicPartition tp = new TopicPartition(record.topic(), record.partition());
@@ -348,7 +348,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                                 + ", Offset: " + record.offset());
                     }
                 } else {
-                    firstOffsets.putIfAbsent(partition, record.offset());
+                    firstValidOffsetsByPartition.putIfAbsent(partition, record.offset());
                     validRecords.add(record);
                 }
             }
@@ -356,7 +356,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
         if (validRecords.isEmpty()) {
             if (isDisableAutoCommit) {
-                commitOffsets(lastOffsets, 1);
+                commitOffsets(lastPolledOffsetsByPartition, 1);
             }
             dlqPublishedOffsets.clear();
             return;
@@ -373,7 +373,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         if (isDisableAutoCommit) {
             if (isConsumed) {
                 retryCounter = 0;
-                commitOffsets(lastOffsets, 1);
+                commitOffsets(lastPolledOffsetsByPartition, 1);
                 dlqPublishedOffsets.clear();
             } else {
                 if (failureRetryInterval > 0 && (retryCounter < failureRetryCount || failureRetryCount < 0)) {
@@ -392,12 +392,12 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                     retryCounter++;
                 }
                 if (retryCounter < failureRetryCount || failureRetryCount < 0) {
-                    for (Map.Entry<TopicPartition, Long> entry : firstOffsets.entrySet()) {
+                    for (Map.Entry<TopicPartition, Long> entry : firstValidOffsetsByPartition.entrySet()) {
                         consumer.seek(entry.getKey(), entry.getValue());
                     }
                 } else {
                     log.warn("The batch offset set to the next record since failure retry count exceeded.");
-                    commitOffsets(lastOffsets, 1);
+                    commitOffsets(lastPolledOffsetsByPartition, 1);
                     dlqPublishedOffsets.clear();
                     retryCounter = 0;
                     injectErrorMessage("Failed to successfully mediate the batch message to/in the sequence: "

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -62,9 +62,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -99,6 +101,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private final Object pauseLock = new Object();  // Dedicated lock for pause/resume operations
     private String dlqTopic;
     private KafkaProducer<byte[], byte[]> dlqProducer;
+    private final Map<TopicPartition, Set<Long>> dlqPublishedOffsets = new HashMap<>();
 
     public KafkaMessageConsumer(Properties properties, String name, SynapseEnvironment synapseEnvironment,
                                 long scanInterval, String injectingSeq, String onErrorSeq, boolean coordination,
@@ -328,11 +331,18 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 lastOffsets.put(partition, record.offset());
                 if (record.value() == null) {
                     if (isPoisonPill(record)) {
-                        log.warn("A poison pill was detected in batch for Topic: " + record.topic()
-                                + ", Partition No: " + record.partition()
-                                + ", Offset: " + record.offset()
-                                + " of Kafka Inbound Endpoint: " + name + ". The record will be skipped.");
-                        publishToDlq(record);
+                        TopicPartition tp = new TopicPartition(record.topic(), record.partition());
+                        if (dlqPublishedOffsets.computeIfAbsent(tp, k -> new HashSet<>()).add(record.offset())) {
+                            log.warn("A poison pill was detected in batch for Topic: " + record.topic()
+                                    + ", Partition No: " + record.partition()
+                                    + ", Offset: " + record.offset()
+                                    + " of Kafka Inbound Endpoint: " + name + ". The record will be skipped.");
+                            publishToDlq(record);
+                        } else {
+                            log.warn("Skipping duplicate DLQ publish for poison pill at Topic: " + record.topic()
+                                    + ", Partition No: " + record.partition()
+                                    + ", Offset: " + record.offset());
+                        }
                     } else {
                         log.warn("A null record was passed and skipped in batch for Topic: " + record.topic()
                                 + ", Partition No: " + record.partition()
@@ -349,6 +359,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             if (isDisableAutoCommit) {
                 commitOffsets(lastOffsets, 1);
             }
+            dlqPublishedOffsets.clear();
             return;
         }
 
@@ -364,6 +375,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             if (isConsumed) {
                 retryCounter = 0;
                 commitOffsets(lastOffsets, 1);
+                dlqPublishedOffsets.clear();
             } else {
                 if (failureRetryInterval > 0 && (retryCounter < failureRetryCount || failureRetryCount < 0)) {
                     try {
@@ -387,6 +399,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 } else {
                     log.warn("The batch offset set to the next record since failure retry count exceeded.");
                     commitOffsets(lastOffsets, 1);
+                    dlqPublishedOffsets.clear();
                     retryCounter = 0;
                     injectErrorMessage("Failed to successfully mediate the batch message to/in the sequence: "
                             + this.injectingSeq + " of Kafka Inbound Endpoint: " + name + ", even after "

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -443,6 +443,13 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         return KafkaConstants.CONTENT_TYPE_APPLICATION_XML;
     }
 
+    /**
+     * Build a batch payload by wrapping each record's raw value, XML-escaped, in a text element
+     * inside the batch root element. Used when the content type is neither JSON nor XML.
+     *
+     * @param records records to include in the batch
+     * @return the batch payload as an XML string with escaped text elements
+     */
     private String buildBatchTextPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder(KafkaConstants.BATCH_XML_ROOT_START_TAG);
         for (ConsumerRecord<byte[], byte[]> record : records) {
@@ -454,6 +461,12 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         return sb.toString();
     }
 
+    /**
+     * Build a JSON array payload by concatenating each record's raw value as a JSON element.
+     *
+     * @param records records to include in the batch
+     * @return the batch payload as a JSON array string
+     */
     private String buildBatchJsonPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < records.size(); i++) {
@@ -466,6 +479,14 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         return sb.toString();
     }
 
+    /**
+     * Build an XML batch payload by concatenating each record's raw value, unescaped, inside the
+     * batch root element. Used when the content type is XML, so each record value is expected to
+     * already be well-formed XML.
+     *
+     * @param records records to include in the batch
+     * @return the batch payload as an XML string
+     */
     private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder(KafkaConstants.BATCH_XML_ROOT_START_TAG);
         for (ConsumerRecord<byte[], byte[]> record : records) {
@@ -475,6 +496,13 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         return sb.toString();
     }
 
+    /**
+     * Convert a record value to its string representation. Byte arrays are decoded as UTF-8;
+     * any other type falls back to {@code toString()}.
+     *
+     * @param value the record value to convert
+     * @return the string representation of the value
+     */
     private String recordValueToString(Object value) {
         if (value instanceof byte[]) {
             return new String((byte[]) value, StandardCharsets.UTF_8);

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -367,8 +367,8 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                 if (failureRetryInterval > 0 && (retryCounter < failureRetryCount || failureRetryCount < 0)) {
                     try {
                         if (log.isDebugEnabled()) {
-                            log.debug("Failed Kafka batch will be retried after max(poll_interval,"
-                                    + " failure_retry_interval): "
+                            log.debug("Failed Kafka batch will be retried after max(interval,"
+                                    + " failure.retry.interval): "
                                     + Long.max(failureRetryInterval, scanInterval) + "ms.");
                         }
                         Thread.sleep(this.failureRetryInterval);

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -407,18 +407,18 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         if ("application/xml".equalsIgnoreCase(type) || "text/xml".equalsIgnoreCase(type)) {
             return buildBatchXmlPayload(records);
         }
-        if ("text/plain".equalsIgnoreCase(type)) {
-            return buildBatchTextPayload(records);
+        if ("application/json".equalsIgnoreCase(type)) {
+            return buildBatchJsonPayload(records);
         }
-        return buildBatchJsonPayload(records);
+        return buildBatchTextPayload(records);
     }
 
     private String getBatchContentType() {
         String type = contentType != null ? contentType.split(";")[0].trim() : "";
-        if ("text/plain".equalsIgnoreCase(type)) {
-            return "application/xml";
+        if ("application/json".equalsIgnoreCase(type)) {
+            return contentType;
         }
-        return contentType;
+        return "application/xml";
     }
 
     private String buildBatchTextPayload(List<ConsumerRecord<byte[], byte[]>> records) {

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -420,8 +420,8 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     }
 
     /**
-     * Build a JSON array string from the given records. Each element is the raw record value,
-     * matching the payload format used in single-record mode.
+     * Build the batch payload for the given records, delegating to {@link #buildBatchXmlPayload},
+     * {@link #buildBatchJsonPayload}, or {@link #buildBatchTextPayload} based on the content type.
      */
     private String buildBatchPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         String type = contentType != null ? contentType.split(";")[0].trim() : "";
@@ -447,6 +447,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
      * Build a batch payload by wrapping each record's raw value, XML-escaped, in a text element
      * inside the batch root element. Used when the content type is neither JSON nor XML.
      *
+     * <p>Sample output for records with values {@code hello} and {@code world}:
+     * <pre>{@code
+     * <messages><text xmlns="http://ws.apache.org/commons/ns/payload">hello</text><text xmlns="http://ws.apache.org/commons/ns/payload">world</text></messages>
+     * }</pre>
+     *
      * @param records records to include in the batch
      * @return the batch payload as an XML string with escaped text elements
      */
@@ -463,6 +468,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
     /**
      * Build a JSON array payload by concatenating each record's raw value as a JSON element.
+     *
+     * <p>Sample output for records with values {@code {"id":1}} and {@code {"id":2}}:
+     * <pre>{@code
+     * [{"id":1},{"id":2}]
+     * }</pre>
      *
      * @param records records to include in the batch
      * @return the batch payload as a JSON array string
@@ -483,6 +493,11 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
      * Build an XML batch payload by concatenating each record's raw value, unescaped, inside the
      * batch root element. Used when the content type is XML, so each record value is expected to
      * already be well-formed XML.
+     *
+     * <p>Sample output for records with values {@code <order>1</order>} and {@code <order>2</order>}:
+     * <pre>{@code
+     * <messages><order>1</order><order>2</order></messages>
+     * }</pre>
      *
      * @param records records to include in the batch
      * @return the batch payload as an XML string

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -18,7 +18,6 @@
 package org.wso2.carbon.inbound.kafka;
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
-import org.apache.avro.generic.GenericData;
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.builder.Builder;
 import org.apache.axis2.builder.BuilderUtil;
@@ -32,11 +31,16 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.wso2.carbon.inbound.kafka.deserializer.DeserializationException;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.SynapseException;
@@ -72,6 +76,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
 
     private static final Log log = LogFactory.getLog(KafkaMessageConsumer.class);
 
+
     private KafkaConsumer<byte[], byte[]> consumer;
 
     private String bootstrapServersName;
@@ -91,6 +96,8 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private String kafkaHeaderPrefix = "";
     private boolean isPaused = false;  // No need for volatile with synchronized access
     private final Object pauseLock = new Object();  // Dedicated lock for pause/resume operations
+    private String dlqTopic;
+    private KafkaProducer<byte[], byte[]> dlqProducer;
 
     public KafkaMessageConsumer(Properties properties, String name, SynapseEnvironment synapseEnvironment,
                                 long scanInterval, String injectingSeq, String onErrorSeq, boolean coordination,
@@ -324,6 +331,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                                 + ", Partition No: " + record.partition()
                                 + ", Offset: " + record.offset()
                                 + " of Kafka Inbound Endpoint: " + name + ". The record will be skipped.");
+                        publishToDlq(record);
                     } else {
                         log.warn("A null record was passed and skipped in batch for Topic: " + record.topic()
                                 + ", Partition No: " + record.partition()
@@ -425,7 +433,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
             sb.append("<text xmlns=\"http://ws.apache.org/commons/ns/payload\">")
-                    .append(escapeXml(new String(record.value(), StandardCharsets.UTF_8)))
+                    .append(escapeXml(recordValueToString(record.value())))
                     .append("</text>");
         }
         sb.append("</messages>");
@@ -438,7 +446,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             if (i > 0) {
                 sb.append(",");
             }
-            sb.append(new String(records.get(i).value(), StandardCharsets.UTF_8));
+            sb.append(recordValueToString(records.get(i).value()));
         }
         sb.append("]");
         return sb.toString();
@@ -447,10 +455,17 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            sb.append(new String(record.value(), StandardCharsets.UTF_8));
+            sb.append(recordValueToString(record.value()));
         }
         sb.append("</messages>");
         return sb.toString();
+    }
+
+    private String recordValueToString(Object value) {
+        if (value instanceof byte[]) {
+            return new String((byte[]) value, StandardCharsets.UTF_8);
+        }
+        return value.toString();
     }
 
     private String escapeXml(String input) {
@@ -481,6 +496,12 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
                         KafkaConstants.BATCH_PROCESSING_ENABLED_DEFAULT));
         if (properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX) != null) {
             kafkaHeaderPrefix = properties.getProperty(KafkaConstants.KAFKA_HEADER_PREFIX).trim();
+        }
+        dlqTopic = properties.getProperty(KafkaConstants.DLQ_TOPIC);
+        if (!StringUtils.isEmpty(dlqTopic)) {
+            dlqProducer = initDlqProducer();
+            log.info("DLQ producer initialized for Kafka Inbound Endpoint: " + name
+                    + ". Poison pills will be published to topic: " + dlqTopic);
         }
     }
 
@@ -514,12 +535,134 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     }
 
     /**
+     * Build a KafkaProducer for publishing poison pills to the DLQ topic.
+     * Reuses bootstrap.servers and all security (SSL/SASL) settings from the consumer config.
+     */
+    private KafkaProducer<byte[], byte[]> initDlqProducer() {
+        Properties producerProps = new Properties();
+        kafkaProperties.stringPropertyNames().stream()
+                .filter(ProducerConfig.configNames()::contains)
+                .forEach(key -> producerProps.put(key, kafkaProperties.getProperty(key)));
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.ByteArraySerializer");
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.ByteArraySerializer");
+        return new KafkaProducer<>(producerProps);
+    }
+
+    /**
+     * Publish a poison pill record to the configured DLQ topic.
+     * The DLQ record carries the original raw bytes as its value and provenance headers
+     * that follow the Spring Kafka DLT naming convention.
+     *
+     * @param record the poison pill ConsumerRecord
+     */
+    private void publishToDlq(ConsumerRecord<byte[], byte[]> record) {
+        if (dlqProducer == null) {
+            log.warn("No DLQ topic configured for Kafka Inbound Endpoint: " + name
+                    + ". Poison pill at topic=" + record.topic()
+                    + " partition=" + record.partition()
+                    + " offset=" + record.offset() + " will be skipped.");
+            return;
+        }
+
+        byte[] originalBytes = null;
+        String exceptionMessage = "Unknown deserialization error";
+        String causeMessage = "";
+
+        DeserializationException ex = readDeserializationException(record);
+        if (ex != null) {
+            originalBytes = ex.getData();
+            exceptionMessage = ex.getMessage();
+            if (ex.getCause() != null && ex.getCause().getMessage() != null) {
+                causeMessage = ex.getCause().getMessage();
+            }
+        }
+
+        List<Header> dlqHeaders = buildDlqHeaders(record, exceptionMessage, causeMessage);
+        ProducerRecord<byte[], byte[]> dlqRecord = new ProducerRecord<>(
+                dlqTopic, null, record.key(), originalBytes, dlqHeaders);
+
+        try {
+            dlqProducer.send(dlqRecord).get();
+            log.info("Poison pill published to DLQ topic=" + dlqTopic
+                    + " from source topic=" + record.topic()
+                    + " partition=" + record.partition()
+                    + " offset=" + record.offset());
+        } catch (Exception e) {
+            log.error("Failed to publish poison pill to DLQ topic=" + dlqTopic
+                    + " from source topic=" + record.topic()
+                    + " offset=" + record.offset(), e);
+        }
+    }
+
+    /**
+     * Extracts the deserialization exception from the poison pill record headers.
+     * Checks the key deserializer exception header first, then the value deserializer exception header.
+     *
+     * @param record the poison pill ConsumerRecord
+     * @return the DeserializationException, or null if no exception header is present or it cannot be read
+     */
+    private DeserializationException readDeserializationException(ConsumerRecord<byte[], byte[]> record) {
+        Header exceptionHeader = record.headers().lastHeader(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER);
+        if (exceptionHeader == null) {
+            exceptionHeader = record.headers().lastHeader(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+        }
+        if (exceptionHeader == null) {
+            return null;
+        }
+        try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(exceptionHeader.value()))) {
+            return (DeserializationException) ois.readObject();
+        } catch (Exception e) {
+            log.warn("Could not read deserialization exception from poison pill header for topic="
+                    + record.topic() + " offset=" + record.offset(), e);
+            return null;
+        }
+    }
+
+    /**
+     * Builds the header list for the DLQ record. Copies all original record headers except the internal
+     * deserialization exception headers, then appends provenance headers describing the origin of the
+     * poison pill and the deserialization failure.
+     *
+     * @param record           the original poison pill ConsumerRecord
+     * @param exceptionMessage the top-level deserialization error message
+     * @param causeMessage     the root cause message, or empty string if none
+     * @return the list of headers to attach to the DLQ ProducerRecord
+     */
+    private List<Header> buildDlqHeaders(ConsumerRecord<byte[], byte[]> record, String exceptionMessage,
+            String causeMessage) {
+        List<Header> dlqHeaders = new ArrayList<>();
+        for (Header h : record.headers()) {
+            if (!h.key().equals(KafkaConstants.KEY_DESERIALIZER_EXCEPTION_HEADER)
+                    && !h.key().equals(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER)) {
+                dlqHeaders.add(h);
+            }
+        }
+        dlqHeaders.add(new RecordHeader(KafkaConstants.DLT_ORIGINAL_TOPIC,
+                record.topic().getBytes(StandardCharsets.UTF_8)));
+        dlqHeaders.add(new RecordHeader(KafkaConstants.DLT_ORIGINAL_PARTITION,
+                String.valueOf(record.partition()).getBytes(StandardCharsets.UTF_8)));
+        dlqHeaders.add(new RecordHeader(KafkaConstants.DLT_ORIGINAL_OFFSET,
+                String.valueOf(record.offset()).getBytes(StandardCharsets.UTF_8)));
+        dlqHeaders.add(new RecordHeader(KafkaConstants.DLT_ORIGINAL_TIMESTAMP,
+                String.valueOf(record.timestamp()).getBytes(StandardCharsets.UTF_8)));
+        dlqHeaders.add(new RecordHeader(KafkaConstants.DLT_EXCEPTION_MESSAGE,
+                exceptionMessage.getBytes(StandardCharsets.UTF_8)));
+        if (!causeMessage.isEmpty()) {
+            dlqHeaders.add(new RecordHeader(KafkaConstants.DLT_EXCEPTION_CAUSE_MESSAGE,
+                    causeMessage.getBytes(StandardCharsets.UTF_8)));
+        }
+        return dlqHeaders;
+    }
+
+    /**
      * Set the Kafka Records to a MessageContext
      *
      * @param record A Kafka record
      * @return MessageContext A message context with the record header values
      */
-    private MessageContext populateMessageContext(ConsumerRecord record) {
+    private MessageContext populateMessageContext(ConsumerRecord<byte[], byte[]> record) {
         MessageContext msgCtx = createMessageContext();
         msgCtx.setProperty(KafkaConstants.KAFKA_PARTITION_NO, record.partition());
         msgCtx.setProperty(KafkaConstants.KAFKA_MESSAGE_VALUE, record.value());
@@ -530,10 +673,6 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         msgCtx.setProperty(KafkaConstants.KAFKA_TIMESTAMP_TYPE, record.timestampType());
         msgCtx.setProperty(KafkaConstants.KAFKA_TOPIC, record.topic());
         msgCtx.setProperty(KafkaConstants.KAFKA_KEY, record.key());
-        if (record.value() instanceof GenericData.Record) {
-            GenericData.Record val = (GenericData.Record) record.value();
-            msgCtx.setProperty(KafkaConstants.KAFKA_SCHEMA_NAME, val.getSchema().getFullName());
-        }
         msgCtx.setProperty(KafkaConstants.KAFKA_INBOUND_ENDPOINT_NAME, name);
         msgCtx.setProperty(SynapseConstants.IS_INBOUND, true);
         // Set the kafka headers to the message context
@@ -789,6 +928,16 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
             }
         } catch (Exception e) {
             log.error("Error while shutdown the Kafka consumer " + name + " " + e.getMessage(), e);
+        }
+        if (dlqProducer != null) {
+            try {
+                dlqProducer.close();
+                if (log.isDebugEnabled()) {
+                    log.debug("The DLQ producer has been closed for " + name);
+                }
+            } catch (Exception e) {
+                log.error("Error while closing the DLQ producer for " + name, e);
+            }
         }
     }
 

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -556,7 +556,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
     private String buildBatchXmlPayload(List<ConsumerRecord<byte[], byte[]>> records) {
         StringBuilder sb = new StringBuilder("<messages>");
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            sb.append(escapeXml(new String(record.value(), StandardCharsets.UTF_8)));
+            sb.append(new String(record.value(), StandardCharsets.UTF_8));
         }
         sb.append("</messages>");
         return sb.toString();
@@ -568,9 +568,7 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
         }
         return input.replace("&", "&amp;")
                 .replace("<", "&lt;")
-                .replace(">", "&gt;")
-                .replace("\"", "&quot;")
-                .replace("'", "&apos;");
+                .replace(">", "&gt;");
     }
 
     private String escapeJson(String input) {

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -358,8 +358,8 @@
           {
             "type": "attribute",
             "value": {
-              "name": "batch.messages.enabled",
-              "displayName": "Enable Batch Messages",
+              "name": "batch.processing.enabled",
+              "displayName": "Enable Batch Processing",
               "inputType": "boolean",
               "defaultValue": false,
               "required": "false",

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -363,7 +363,17 @@
               "inputType": "boolean",
               "defaultValue": false,
               "required": "false",
-              "helpTip": "When enabled, all records from a single poll are injected as a JSON array to the insequence in one invocation instead of one record at a time. Poison pill errors are also batched and injected once to the onError sequence."
+              "helpTip": "When enabled, all records from a single poll are injected as a batch to the insequence in one invocation instead of one record at a time."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
+              "name": "kafka.dlq.topic",
+              "displayName": "Dead Letter Queue (DLQ) Topic",
+              "inputType": "string",
+              "required": "false",
+              "helpTip": "Kafka topic to which poison pill records (records that fail deserialization) are forwarded. When configured, poison pills in a batch are published to this topic with provenance headers instead of being silently skipped."
             }
           },
           {

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -358,6 +358,17 @@
           {
             "type": "attribute",
             "value": {
+              "name": "batch.messages.enabled",
+              "displayName": "Enable Batch Messages",
+              "inputType": "boolean",
+              "defaultValue": false,
+              "required": "false",
+              "helpTip": "When enabled, all records from a single poll are injected as a JSON array to the insequence in one invocation instead of one record at a time. Poison pill errors are also batched and injected once to the onError sequence."
+            }
+          },
+          {
+            "type": "attribute",
+            "value": {
               "name": "kafka.header.prefix",
               "displayName": "Kafka Header Prefix",
               "inputType": "string",

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -373,7 +373,8 @@
               "displayName": "Dead Letter Queue (DLQ) Topic",
               "inputType": "string",
               "required": "false",
-              "helpTip": "Kafka topic to which poison pill records (records that fail deserialization) are forwarded. When configured, poison pills in a batch are published to this topic with provenance headers instead of being silently skipped."
+              "helpTip": "Kafka topic to which poison pill records are forwarded. When configured, poison pills in a batch are published to this topic with provenance headers.",
+              "enableCondition": [{"batch.processing.enabled": "true"}]
             }
           },
           {

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.synapse.config.SynapseConfiguration;
@@ -155,6 +156,7 @@ class KafkaMessageConsumerBatchTest {
         return new ConsumerRecords<>(map);
     }
 
+    /** Invokes a private method on {@code target} via reflection, bypassing access control. */
     private static Object callPrivate(Object target, String methodName,
             Class<?>[] argTypes, Object... args) throws Exception {
         Method m = target.getClass().getDeclaredMethod(methodName, argTypes);
@@ -162,18 +164,21 @@ class KafkaMessageConsumerBatchTest {
         return m.invoke(target, args);
     }
 
+    /** Sets a private field on {@code target} via reflection, bypassing access control. */
     private static void setField(Object target, String fieldName, Object value) throws Exception {
         Field f = findField(target.getClass(), fieldName);
         f.setAccessible(true);
         f.set(target, value);
     }
 
+    /** Reads a private field from {@code target} via reflection, bypassing access control. */
     private static Object getField(Object target, String fieldName) throws Exception {
         Field f = findField(target.getClass(), fieldName);
         f.setAccessible(true);
         return f.get(target);
     }
 
+    /** Walks the class hierarchy to find a declared field by name, including inherited private fields. */
     private static Field findField(Class<?> c, String name) {
         while (c != null) {
             try { return c.getDeclaredField(name); } catch (NoSuchFieldException ignored) {}
@@ -217,6 +222,42 @@ class KafkaMessageConsumerBatchTest {
         String result = (String) callPrivate(consumer, "buildBatchPayload",
                 new Class[]{List.class}, Collections.emptyList());
         assertEquals("[]", result);
+    }
+
+    @Test
+    void buildBatchPayload_applicationXml_wrapsRecordsInMessagesRoot() throws Exception {
+        setField(consumer, "contentType", "application/xml");
+        List<ConsumerRecord<byte[], byte[]>> list = Arrays.asList(
+                record(TOPIC, 0, 0L, "<item>one</item>".getBytes()),
+                record(TOPIC, 0, 1L, "<item>two</item>".getBytes()));
+        String result = (String) callPrivate(consumer, "buildBatchPayload",
+                new Class[]{List.class}, list);
+        assertEquals("<messages><item>one</item><item>two</item></messages>", result);
+    }
+
+    @Test
+    void buildBatchPayload_textXml_wrapsRecordsInMessagesRoot() throws Exception {
+        setField(consumer, "contentType", "text/xml");
+        ConsumerRecord<byte[], byte[]> r = record(TOPIC, 0, 0L, "<item>one</item>".getBytes());
+        String result = (String) callPrivate(consumer, "buildBatchPayload",
+                new Class[]{List.class}, Collections.singletonList(r));
+        assertEquals("<messages><item>one</item></messages>", result);
+    }
+
+    @Test
+    void buildBatchPayload_textPlain_wrapsInTextElementsAndEscapesXml() throws Exception {
+        setField(consumer, "contentType", "text/plain");
+        List<ConsumerRecord<byte[], byte[]>> list = Arrays.asList(
+                record(TOPIC, 0, 0L, "hello".getBytes()),
+                record(TOPIC, 0, 1L, "a<b>&c".getBytes()));
+        String result = (String) callPrivate(consumer, "buildBatchPayload",
+                new Class[]{List.class}, list);
+        assertEquals(
+                "<messages>" +
+                "<text xmlns=\"http://ws.apache.org/commons/ns/payload\">hello</text>" +
+                "<text xmlns=\"http://ws.apache.org/commons/ns/payload\">a&lt;b&gt;&amp;c</text>" +
+                "</messages>",
+                result);
     }
 
     // ── commitRecordsAsBatch — trivial cases ───────────────────────────────────
@@ -418,6 +459,278 @@ class KafkaMessageConsumerBatchTest {
                     ArgumentCaptor.forClass((Class) Map.class);
             verify(mockKafkaConsumer).commitSync(captor.capture());
             assertEquals(2L, captor.getValue().get(new TopicPartition(TOPIC, 0)).offset());
+        }
+    }
+
+    // ── commitRecordsAsBatch — auto-commit + failure ───────────────────────────
+
+    @Test
+    void commitRecordsAsBatch_validRecords_autoCommit_failure_noSeekNoCommit() throws Exception {
+        // With auto-commit, a failed injection is silently ignored — no seek, no manual commit.
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(consumer, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 5L, "msg".getBytes()))));
+
+            verify(mockKafkaConsumer, never()).seek(any(), anyLong());
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
+        }
+    }
+
+    // ── commitRecordsAsBatch — multi-partition ─────────────────────────────────
+
+    @Test
+    void commitRecordsAsBatch_multiPartition_manualCommit_success_commitsAllPartitions()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionMap = new HashMap<>();
+        partitionMap.put(tp0, Arrays.asList(
+                record(TOPIC, 0, 10L, "a".getBytes()),
+                record(TOPIC, 0, 11L, "b".getBytes())));
+        partitionMap.put(tp1, Arrays.asList(
+                record(TOPIC, 1, 20L, "c".getBytes()),
+                record(TOPIC, 1, 21L, "d".getBytes())));
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class}, new ConsumerRecords<>(partitionMap));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                    ArgumentCaptor.forClass((Class) Map.class);
+            verify(mockKafkaConsumer).commitSync(captor.capture());
+            Map<TopicPartition, OffsetAndMetadata> committed = captor.getValue();
+            assertEquals(12L, committed.get(tp0).offset(), "partition 0: lastOffset(11)+1");
+            assertEquals(22L, committed.get(tp1).offset(), "partition 1: lastOffset(21)+1");
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_multiPartition_manualCommit_failure_seeksAllPartitionsToFirstOffset()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+        TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> partitionMap = new HashMap<>();
+        partitionMap.put(tp0, Arrays.asList(
+                record(TOPIC, 0, 10L, "a".getBytes()),
+                record(TOPIC, 0, 11L, "b".getBytes())));
+        partitionMap.put(tp1, Arrays.asList(
+                record(TOPIC, 1, 20L, "c".getBytes()),
+                record(TOPIC, 1, 21L, "d".getBytes())));
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class}, new ConsumerRecords<>(partitionMap));
+
+            verify(mockKafkaConsumer).seek(tp0, 10L);
+            verify(mockKafkaConsumer).seek(tp1, 20L);
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
+        }
+    }
+
+    // ── commitRecordsAsBatch — retryCounter lifecycle ──────────────────────────
+
+    @Test
+    void commitRecordsAsBatch_failure_incrementsRetryCounter() throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 5L, "msg".getBytes()))));
+
+            assertEquals(1, (int) getField(mc, "retryCounter"));
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_successAfterPreviousFailures_resetsRetryCounterToZero()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        setField(mc, "retryCounter", 2);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 5L, "msg".getBytes()))));
+
+            assertEquals(0, (int) getField(mc, "retryCounter"));
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_retryExhaustion_resetsRetryCounterToZero() throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        setField(mc, "retryCounter", 3);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 5L, "msg".getBytes()))));
+
+            assertEquals(0, (int) getField(mc, "retryCounter"));
+        }
+    }
+
+    // ── commitRecordsAsBatch — failureRetryCount edge values ───────────────────
+
+    @Test
+    void commitRecordsAsBatch_infiniteRetryCount_alwaysSeeksNeverCommits() throws Exception {
+        // failureRetryCount=-1 is the default when the property is absent
+        Properties p = baseProps(true, false);
+        p.setProperty(KafkaConstants.ENABLE_AUTO_COMMIT, "false");
+        KafkaMessageConsumer mc = new KafkaMessageConsumer(p, ENDPOINT_NAME,
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        setField(mc, "consumer", mockKafkaConsumer);
+        setField(mc, "retryCounter", 100);  // large value; infinite mode never exhausts
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 5L, "msg".getBytes()))));
+
+            verify(mockKafkaConsumer).seek(new TopicPartition(TOPIC, 0), 5L);
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_zeroRetryCount_exhaustsImmediatelyOnFirstFailure() throws Exception {
+        Properties p = baseProps(true, false);
+        p.setProperty(KafkaConstants.ENABLE_AUTO_COMMIT, "false");
+        p.setProperty(KafkaConstants.FAILURE_RETRY_COUNT, "0");
+        KafkaMessageConsumer mc = new KafkaMessageConsumer(p, ENDPOINT_NAME,
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        setField(mc, "consumer", mockKafkaConsumer);
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 5L, "msg".getBytes()))));
+
+            verify(mockKafkaConsumer, never()).seek(any(), anyLong());
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                    ArgumentCaptor.forClass((Class) Map.class);
+            verify(mockKafkaConsumer).commitSync(captor.capture());
+            assertEquals(6L, captor.getValue().get(tp).offset());
+            // batch injection + error injection = 2 calls
+            verify(synapseEnvironment, times(2)).injectInbound(any(), any(), anyBoolean());
+        }
+    }
+
+    // ── commitRecordsAsBatch — DLQ ─────────────────────────────────────────────
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void commitRecordsAsBatch_poisonPill_dlqConfigured_sendsRecordToDlq() throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        KafkaProducer<byte[], byte[]> mockDlqProducer = mock(KafkaProducer.class);
+        setField(mc, "dlqTopic", "dlq-topic");
+        setField(mc, "dlqProducer", mockDlqProducer);
+
+        callPrivate(mc, "commitRecordsAsBatch",
+                new Class[]{ConsumerRecords.class},
+                makeRecords(TOPIC, 0, Collections.singletonList(
+                        poisonPillRecord(TOPIC, 0, 3L, "deser error"))));
+
+        verify(mockDlqProducer).send(any(), any());
+    }
+
+    // ── commitRecordsAsBatch — null + valid mix, failure seek ──────────────────
+
+    @Test
+    void commitRecordsAsBatch_nullBeforeValidRecord_failure_seeksToFirstValidOffset()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            // offset 5: null (skipped), offset 7: first valid record
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Arrays.asList(
+                            nullValueRecord(TOPIC, 0, 5L),
+                            record(TOPIC, 0, 7L, "msg".getBytes()))));
+
+            // seek must land on the first valid record's offset, not the null record's offset
+            verify(mockKafkaConsumer).seek(tp, 7L);
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
         }
     }
 

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -386,26 +386,6 @@ class KafkaMessageConsumerBatchTest {
         }
     }
 
-    @Test
-    void commitRecordsAsBatch_validRecords_autoCommit_setsBatchSizeOnMessageContext()
-            throws Exception {
-        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
-             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
-             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
-                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
-                             .thenReturn(omElement))) {
-            stubAxis2(bu, tu);
-            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
-
-            callPrivate(consumer, "commitRecordsAsBatch",
-                    new Class[]{ConsumerRecords.class},
-                    makeRecords(TOPIC, 0, Arrays.asList(
-                            record(TOPIC, 0, 0L, "a".getBytes()),
-                            record(TOPIC, 0, 1L, "b".getBytes()))));
-
-            verify(synapseMessageContext).setProperty(KafkaConstants.KAFKA_BATCH_SIZE, 2);
-        }
-    }
 
     // ── commitRecordsAsBatch — valid records, manual commit ───────────────────
 

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright (c) 2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.inbound.kafka;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axis2.builder.BuilderUtil;
+import org.apache.axis2.builder.SOAPBuilder;
+import org.apache.axis2.context.OperationContext;
+import org.apache.axis2.transport.TransportUtils;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.synapse.config.SynapseConfiguration;
+import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.core.axis2.Axis2MessageContext;
+import org.apache.synapse.mediators.base.SequenceMediator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class KafkaMessageConsumerBatchTest {
+
+    private static final String TOPIC = "test-topic";
+    private static final String INBOUND_SEQ = "inSeq";
+    private static final String ERROR_SEQ = "errorSeq";
+    private static final String ENDPOINT_NAME = "test-ep";
+
+    @Mock private SynapseEnvironment synapseEnvironment;
+    @Mock private Axis2MessageContext synapseMessageContext;
+    @Mock private org.apache.axis2.context.MessageContext axis2Ctx;
+    @Mock private SynapseConfiguration synapseConfiguration;
+    @Mock private SequenceMediator sequenceMediator;
+    @Mock private KafkaConsumer<byte[], byte[]> mockKafkaConsumer;
+    @Mock private OperationContext operationContext;
+    @Mock private OMElement omElement;
+    @Mock private SOAPEnvelope soapEnvelope;
+
+    private KafkaMessageConsumer consumer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        when(synapseEnvironment.createMessageContext()).thenReturn(synapseMessageContext);
+        when(synapseMessageContext.getAxis2MessageContext()).thenReturn(axis2Ctx);
+        when(axis2Ctx.getOperationContext()).thenReturn(operationContext);
+        when(synapseEnvironment.getSynapseConfiguration()).thenReturn(synapseConfiguration);
+        when(synapseConfiguration.getSequence(anyString())).thenReturn(sequenceMediator);
+
+        consumer = new KafkaMessageConsumer(baseProps(true, false), ENDPOINT_NAME,
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        setField(consumer, "consumer", mockKafkaConsumer);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /** Minimal properties sufficient to construct a KafkaMessageConsumer. */
+    private static Properties baseProps(boolean batchEnabled, boolean manualCommit) {
+        Properties p = new Properties();
+        p.setProperty(KafkaConstants.BOOTSTRAP_SERVERS_NAME, "localhost:9092");
+        p.setProperty(KafkaConstants.KEY_DESERIALIZER,
+                "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        p.setProperty(KafkaConstants.VALUE_DESERIALIZER,
+                "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        p.setProperty(KafkaConstants.GROUP_ID, "test-group");
+        p.setProperty(KafkaConstants.POLL_TIMEOUT, "100");
+        p.setProperty(KafkaConstants.TOPIC_NAME, TOPIC);
+        p.setProperty(KafkaConstants.CONTENT_TYPE, "application/json");
+        p.setProperty(KafkaConstants.BATCH_MESSAGES_ENABLED, String.valueOf(batchEnabled));
+        if (manualCommit) {
+            p.setProperty(KafkaConstants.ENABLE_AUTO_COMMIT, "false");
+            p.setProperty(KafkaConstants.FAILURE_RETRY_COUNT, "3");
+        }
+        return p;
+    }
+
+    /** Creates a consumer with manual commit and failureRetryCount=3. */
+    private KafkaMessageConsumer manualCommitConsumer() throws Exception {
+        KafkaMessageConsumer c = new KafkaMessageConsumer(baseProps(true, true), ENDPOINT_NAME,
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        setField(c, "consumer", mockKafkaConsumer);
+        return c;
+    }
+
+    private static ConsumerRecord<byte[], byte[]> record(String topic, int partition,
+            long offset, byte[] value) {
+        return new ConsumerRecord<>(topic, partition, offset, null, value);
+    }
+
+    private static ConsumerRecord<byte[], byte[]> nullValueRecord(String topic, int partition,
+            long offset) {
+        return new ConsumerRecord<>(topic, partition, offset, null, null);
+    }
+
+    private static ConsumerRecord<byte[], byte[]> poisonPillRecord(String topic, int partition,
+            long offset, String errorMsg) throws IOException {
+        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(topic, partition, offset, null, null);
+        r.headers().add(KafkaConstants.VALUE_DESERIALIZER_EXCEPTION_HEADER,
+                serialize(new KafkaException(errorMsg)));
+        return r;
+    }
+
+    private static byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(obj);
+        }
+        return bos.toByteArray();
+    }
+
+    private static ConsumerRecords<byte[], byte[]> makeRecords(String topic, int partition,
+            List<ConsumerRecord<byte[], byte[]>> list) {
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> map = new HashMap<>();
+        map.put(new TopicPartition(topic, partition), list);
+        return new ConsumerRecords<>(map);
+    }
+
+    private static Object callPrivate(Object target, String methodName,
+            Class<?>[] argTypes, Object... args) throws Exception {
+        Method m = target.getClass().getDeclaredMethod(methodName, argTypes);
+        m.setAccessible(true);
+        return m.invoke(target, args);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field f = findField(target.getClass(), fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private static Object getField(Object target, String fieldName) throws Exception {
+        Field f = findField(target.getClass(), fieldName);
+        f.setAccessible(true);
+        return f.get(target);
+    }
+
+    private static Field findField(Class<?> c, String name) {
+        while (c != null) {
+            try { return c.getDeclaredField(name); } catch (NoSuchFieldException ignored) {}
+            c = c.getSuperclass();
+        }
+        throw new IllegalArgumentException("Field not found: " + name);
+    }
+
+    /**
+     * Stubs the Axis2 static entry-points so that injectMessage() can reach
+     * synapseEnvironment.injectInbound() without throwing.
+     */
+    private void stubAxis2(MockedStatic<BuilderUtil> bu, MockedStatic<TransportUtils> tu) {
+        bu.when(() -> BuilderUtil.getBuilderFromSelector(anyString(), any())).thenReturn(null);
+        tu.when(() -> TransportUtils.createSOAPEnvelope(any())).thenReturn(soapEnvelope);
+    }
+
+    // ── buildBatchPayload ──────────────────────────────────────────────────────
+
+    @Test
+    void buildBatchPayload_singleRecord_producesJsonArray() throws Exception {
+        ConsumerRecord<byte[], byte[]> r = record(TOPIC, 0, 0L, "{\"k\":1}".getBytes());
+        String result = (String) callPrivate(consumer, "buildBatchPayload",
+                new Class[]{List.class}, Collections.singletonList(r));
+        assertEquals("[{\"k\":1}]", result);
+    }
+
+    @Test
+    void buildBatchPayload_multipleRecords_commaDelimited() throws Exception {
+        List<ConsumerRecord<byte[], byte[]>> list = Arrays.asList(
+                record(TOPIC, 0, 0L, "A".getBytes()),
+                record(TOPIC, 0, 1L, "B".getBytes()),
+                record(TOPIC, 0, 2L, "C".getBytes()));
+        String result = (String) callPrivate(consumer, "buildBatchPayload",
+                new Class[]{List.class}, list);
+        assertEquals("[A,B,C]", result);
+    }
+
+    @Test
+    void buildBatchPayload_emptyList_producesEmptyJsonArray() throws Exception {
+        String result = (String) callPrivate(consumer, "buildBatchPayload",
+                new Class[]{List.class}, Collections.emptyList());
+        assertEquals("[]", result);
+    }
+
+    // ── deserializedToString ───────────────────────────────────────────────────
+
+    @Test
+    void deserializedToString_byteArray_decodesAsUtf8() throws Exception {
+        byte[] input = "héllo".getBytes(StandardCharsets.UTF_8);
+        String result = (String) callPrivate(consumer, "deserializedToString",
+                new Class[]{Object.class}, input);
+        assertEquals("héllo", result);
+    }
+
+    @Test
+    void deserializedToString_stringValue_returnsSameString() throws Exception {
+        String result = (String) callPrivate(consumer, "deserializedToString",
+                new Class[]{Object.class}, "world");
+        assertEquals("world", result);
+    }
+
+    @Test
+    void deserializedToString_arbitraryObject_usesToStringRepresentation() throws Exception {
+        String result = (String) callPrivate(consumer, "deserializedToString",
+                new Class[]{Object.class}, 42);
+        assertEquals("42", result);
+    }
+
+    // ── escapeJson ─────────────────────────────────────────────────────────────
+
+    @Test
+    void escapeJson_nullInput_returnsEmptyString() throws Exception {
+        String result = (String) callPrivate(consumer, "escapeJson",
+                new Class[]{String.class}, (Object) null);
+        assertEquals("", result);
+    }
+
+    @Test
+    void escapeJson_doubleQuotes_escaped() throws Exception {
+        String result = (String) callPrivate(consumer, "escapeJson",
+                new Class[]{String.class}, "say \"hi\"");
+        assertEquals("say \\\"hi\\\"", result);
+    }
+
+    @Test
+    void escapeJson_backslash_escaped() throws Exception {
+        String result = (String) callPrivate(consumer, "escapeJson",
+                new Class[]{String.class}, "a\\b");
+        assertEquals("a\\\\b", result);
+    }
+
+    @Test
+    void escapeJson_newlineAndTab_escaped() throws Exception {
+        String result = (String) callPrivate(consumer, "escapeJson",
+                new Class[]{String.class}, "line\ncolumn\ttab");
+        assertEquals("line\\ncolumn\\ttab", result);
+    }
+
+    @Test
+    void escapeJson_carriageReturn_escaped() throws Exception {
+        String result = (String) callPrivate(consumer, "escapeJson",
+                new Class[]{String.class}, "a\rb");
+        assertEquals("a\\rb", result);
+    }
+
+    // ── buildPoisonPillBatchPayload ────────────────────────────────────────────
+
+    @Test
+    void buildPoisonPillBatchPayload_nullKey_renderedAsJsonNull() throws Exception {
+        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(TOPIC, 2, 10L, null, null);
+        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
+                new Class[]{List.class, List.class},
+                Collections.singletonList(r),
+                Collections.singletonList("deser error"));
+
+        assertTrue(result.contains("\"key\":null"));
+        assertTrue(result.contains("\"topic\":\"test-topic\""));
+        assertTrue(result.contains("\"partition\":2"));
+        assertTrue(result.contains("\"offset\":10"));
+        assertTrue(result.contains("\"errorMessage\":\"deser error\""));
+    }
+
+    @Test
+    void buildPoisonPillBatchPayload_nonNullKey_renderedAsString() throws Exception {
+        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(TOPIC, 0, 0L,
+                "k1".getBytes(), null);
+        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
+                new Class[]{List.class, List.class},
+                Collections.singletonList(r),
+                Collections.singletonList("err"));
+
+        assertFalse(result.contains("\"key\":null"), "non-null key must not render as JSON null");
+        assertTrue(result.contains("\"key\":\""));
+    }
+
+    @Test
+    void buildPoisonPillBatchPayload_multipleRecords_producesValidJsonArray() throws Exception {
+        ConsumerRecord<byte[], byte[]> r1 = new ConsumerRecord<>(TOPIC, 0, 0L, null, null);
+        ConsumerRecord<byte[], byte[]> r2 = new ConsumerRecord<>(TOPIC, 0, 1L, null, null);
+        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
+                new Class[]{List.class, List.class},
+                Arrays.asList(r1, r2),
+                Arrays.asList("e1", "e2"));
+
+        assertTrue(result.startsWith("[") && result.endsWith("]"));
+        assertTrue(result.contains("\"errorMessage\":\"e1\""));
+        assertTrue(result.contains("\"errorMessage\":\"e2\""));
+    }
+
+    @Test
+    void buildPoisonPillBatchPayload_errorMessageWithSpecialChars_jsonEscaped() throws Exception {
+        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(TOPIC, 0, 0L, null, null);
+        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
+                new Class[]{List.class, List.class},
+                Collections.singletonList(r),
+                Collections.singletonList("error: \"broken\""));
+
+        assertTrue(result.contains("\\\"broken\\\""),
+                "double quotes in error message must be JSON-escaped");
+    }
+
+    // ── commitRecordsAsBatch — trivial cases ───────────────────────────────────
+
+    @Test
+    void commitRecordsAsBatch_emptyPoll_doesNotInteractWithKafkaConsumer() throws Exception {
+        callPrivate(consumer, "commitRecordsAsBatch",
+                new Class[]{ConsumerRecords.class}, ConsumerRecords.empty());
+        verifyNoInteractions(mockKafkaConsumer);
+    }
+
+    @Test
+    void commitRecordsAsBatch_onlyNullValueRecords_manualCommit_commitsLastOffsetPlusOne()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        callPrivate(mc, "commitRecordsAsBatch",
+                new Class[]{ConsumerRecords.class},
+                makeRecords(TOPIC, 0,
+                        Collections.singletonList(nullValueRecord(TOPIC, 0, 7L))));
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                ArgumentCaptor.forClass((Class) Map.class);
+        verify(mockKafkaConsumer).commitSync(captor.capture());
+        assertEquals(8L, captor.getValue().get(tp).offset());
+    }
+
+    // ── commitRecordsAsBatch — valid records, auto-commit ─────────────────────
+
+    @Test
+    void commitRecordsAsBatch_validRecords_autoCommit_neverCallsCommitSync() throws Exception {
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(consumer, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Arrays.asList(
+                            record(TOPIC, 0, 5L, "m1".getBytes()),
+                            record(TOPIC, 0, 6L, "m2".getBytes()))));
+
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_validRecords_autoCommit_setsBatchSizeOnMessageContext()
+            throws Exception {
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(consumer, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Arrays.asList(
+                            record(TOPIC, 0, 0L, "a".getBytes()),
+                            record(TOPIC, 0, 1L, "b".getBytes()))));
+
+            verify(synapseMessageContext).setProperty(KafkaConstants.KAFKA_BATCH_SIZE, 2);
+        }
+    }
+
+    // ── commitRecordsAsBatch — valid records, manual commit ───────────────────
+
+    @Test
+    void commitRecordsAsBatch_validRecords_manualCommit_success_commitsLastOffsetPlusOne()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Arrays.asList(
+                            record(TOPIC, 0, 10L, "a".getBytes()),
+                            record(TOPIC, 0, 11L, "b".getBytes()))));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                    ArgumentCaptor.forClass((Class) Map.class);
+            verify(mockKafkaConsumer).commitSync(captor.capture());
+            assertEquals(12L, captor.getValue().get(tp).offset(),
+                    "should commit lastOffset(11) + 1");
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_validRecords_manualCommit_failure_seeksToFirstOffset()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Arrays.asList(
+                            record(TOPIC, 0, 10L, "a".getBytes()),
+                            record(TOPIC, 0, 11L, "b".getBytes()))));
+
+            verify(mockKafkaConsumer).seek(tp, 10L);
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_retryCountExhausted_commitsNextOffsetAndInjectsError()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        setField(mc, "retryCounter", 3);  // already at failureRetryCount (3)
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            record(TOPIC, 0, 20L, "msg".getBytes()))));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                    ArgumentCaptor.forClass((Class) Map.class);
+            verify(mockKafkaConsumer).commitSync(captor.capture());
+            assertEquals(21L, captor.getValue().get(tp).offset(),
+                    "should commit lastOffset(20) + 1 after retry exhaustion");
+            // injectInbound: once for the failed batch injection, once for the error injection
+            verify(synapseEnvironment, times(2)).injectInbound(any(), any(), anyBoolean());
+        }
+    }
+
+    // ── commitRecordsAsBatch — poison pills ────────────────────────────────────
+
+    @Test
+    void commitRecordsAsBatch_onlyPoisonPills_autoCommit_injectsToErrorSequence()
+            throws Exception {
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(consumer, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            poisonPillRecord(TOPIC, 0, 3L, "bad deser"))));
+
+            verify(synapseEnvironment, atLeastOnce())
+                    .injectInbound(any(), eq(sequenceMediator), anyBoolean());
+            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
+        }
+    }
+
+    @Test
+    void commitRecordsAsBatch_onlyPoisonPills_manualCommit_commitsLastOffsetPlusOne()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Collections.singletonList(
+                            poisonPillRecord(TOPIC, 0, 5L, "deser failed"))));
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                    ArgumentCaptor.forClass((Class) Map.class);
+            verify(mockKafkaConsumer).commitSync(captor.capture());
+            assertEquals(6L, captor.getValue().get(tp).offset());
+        }
+    }
+
+    // ── commitRecordsAsBatch — mixed batch ─────────────────────────────────────
+
+    @Test
+    void commitRecordsAsBatch_mixedBatch_poisonPillAndValidRecord_injectsBothSeparately()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            // offset 0 = poison pill, offset 1 = valid record
+            callPrivate(mc, "commitRecordsAsBatch",
+                    new Class[]{ConsumerRecords.class},
+                    makeRecords(TOPIC, 0, Arrays.asList(
+                            poisonPillRecord(TOPIC, 0, 0L, "err"),
+                            record(TOPIC, 0, 1L, "ok".getBytes()))));
+
+            // first call: error sequence for poison pill; second call: inbound sequence for batch
+            verify(synapseEnvironment, times(2)).injectInbound(any(), any(), anyBoolean());
+            // offset committed: lastOffset(1) + 1 = 2
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                    ArgumentCaptor.forClass((Class) Map.class);
+            verify(mockKafkaConsumer).commitSync(captor.capture());
+            assertEquals(2L, captor.getValue().get(new TopicPartition(TOPIC, 0)).offset());
+        }
+    }
+
+    // ── isBatchEnabled configuration ───────────────────────────────────────────
+
+    @Test
+    void isBatchEnabled_whenPropertySetToTrue_fieldIsTrue() throws Exception {
+        assertTrue((Boolean) getField(consumer, "isBatchEnabled"),
+                "consumer created with batch.messages.enabled=true should have isBatchEnabled=true");
+    }
+
+    @Test
+    void isBatchEnabled_whenPropertyAbsent_defaultIsFalse() throws Exception {
+        Properties props = baseProps(false, false);
+        props.remove(KafkaConstants.BATCH_MESSAGES_ENABLED);
+        KafkaMessageConsumer c = new KafkaMessageConsumer(props, "ep",
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        assertFalse((Boolean) getField(c, "isBatchEnabled"),
+                "isBatchEnabled should default to false when property is absent");
+    }
+}

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -47,7 +47,6 @@ import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -220,123 +219,6 @@ class KafkaMessageConsumerBatchTest {
         assertEquals("[]", result);
     }
 
-    // ── deserializedToString ───────────────────────────────────────────────────
-
-    @Test
-    void deserializedToString_byteArray_decodesAsUtf8() throws Exception {
-        byte[] input = "héllo".getBytes(StandardCharsets.UTF_8);
-        String result = (String) callPrivate(consumer, "deserializedToString",
-                new Class[]{Object.class}, input);
-        assertEquals("héllo", result);
-    }
-
-    @Test
-    void deserializedToString_stringValue_returnsSameString() throws Exception {
-        String result = (String) callPrivate(consumer, "deserializedToString",
-                new Class[]{Object.class}, "world");
-        assertEquals("world", result);
-    }
-
-    @Test
-    void deserializedToString_arbitraryObject_usesToStringRepresentation() throws Exception {
-        String result = (String) callPrivate(consumer, "deserializedToString",
-                new Class[]{Object.class}, 42);
-        assertEquals("42", result);
-    }
-
-    // ── escapeJson ─────────────────────────────────────────────────────────────
-
-    @Test
-    void escapeJson_nullInput_returnsEmptyString() throws Exception {
-        String result = (String) callPrivate(consumer, "escapeJson",
-                new Class[]{String.class}, (Object) null);
-        assertEquals("", result);
-    }
-
-    @Test
-    void escapeJson_doubleQuotes_escaped() throws Exception {
-        String result = (String) callPrivate(consumer, "escapeJson",
-                new Class[]{String.class}, "say \"hi\"");
-        assertEquals("say \\\"hi\\\"", result);
-    }
-
-    @Test
-    void escapeJson_backslash_escaped() throws Exception {
-        String result = (String) callPrivate(consumer, "escapeJson",
-                new Class[]{String.class}, "a\\b");
-        assertEquals("a\\\\b", result);
-    }
-
-    @Test
-    void escapeJson_newlineAndTab_escaped() throws Exception {
-        String result = (String) callPrivate(consumer, "escapeJson",
-                new Class[]{String.class}, "line\ncolumn\ttab");
-        assertEquals("line\\ncolumn\\ttab", result);
-    }
-
-    @Test
-    void escapeJson_carriageReturn_escaped() throws Exception {
-        String result = (String) callPrivate(consumer, "escapeJson",
-                new Class[]{String.class}, "a\rb");
-        assertEquals("a\\rb", result);
-    }
-
-    // ── buildPoisonPillBatchPayload ────────────────────────────────────────────
-
-    @Test
-    void buildPoisonPillBatchPayload_nullKey_renderedAsJsonNull() throws Exception {
-        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(TOPIC, 2, 10L, null, null);
-        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
-                new Class[]{List.class, List.class},
-                Collections.singletonList(r),
-                Collections.singletonList("deser error"));
-
-        assertTrue(result.contains("\"key\":null"));
-        assertTrue(result.contains("\"topic\":\"test-topic\""));
-        assertTrue(result.contains("\"partition\":2"));
-        assertTrue(result.contains("\"offset\":10"));
-        assertTrue(result.contains("\"errorMessage\":\"deser error\""));
-    }
-
-    @Test
-    void buildPoisonPillBatchPayload_nonNullKey_renderedAsString() throws Exception {
-        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(TOPIC, 0, 0L,
-                "k1".getBytes(), null);
-        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
-                new Class[]{List.class, List.class},
-                Collections.singletonList(r),
-                Collections.singletonList("err"));
-
-        assertFalse(result.contains("\"key\":null"), "non-null key must not render as JSON null");
-        assertTrue(result.contains("\"key\":\""));
-    }
-
-    @Test
-    void buildPoisonPillBatchPayload_multipleRecords_producesValidJsonArray() throws Exception {
-        ConsumerRecord<byte[], byte[]> r1 = new ConsumerRecord<>(TOPIC, 0, 0L, null, null);
-        ConsumerRecord<byte[], byte[]> r2 = new ConsumerRecord<>(TOPIC, 0, 1L, null, null);
-        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
-                new Class[]{List.class, List.class},
-                Arrays.asList(r1, r2),
-                Arrays.asList("e1", "e2"));
-
-        assertTrue(result.startsWith("[") && result.endsWith("]"));
-        assertTrue(result.contains("\"errorMessage\":\"e1\""));
-        assertTrue(result.contains("\"errorMessage\":\"e2\""));
-    }
-
-    @Test
-    void buildPoisonPillBatchPayload_errorMessageWithSpecialChars_jsonEscaped() throws Exception {
-        ConsumerRecord<byte[], byte[]> r = new ConsumerRecord<>(TOPIC, 0, 0L, null, null);
-        String result = (String) callPrivate(consumer, "buildPoisonPillBatchPayload",
-                new Class[]{List.class, List.class},
-                Collections.singletonList(r),
-                Collections.singletonList("error: \"broken\""));
-
-        assertTrue(result.contains("\\\"broken\\\""),
-                "double quotes in error message must be JSON-escaped");
-    }
-
     // ── commitRecordsAsBatch — trivial cases ───────────────────────────────────
 
     @Test
@@ -477,25 +359,15 @@ class KafkaMessageConsumerBatchTest {
     // ── commitRecordsAsBatch — poison pills ────────────────────────────────────
 
     @Test
-    void commitRecordsAsBatch_onlyPoisonPills_autoCommit_injectsToErrorSequence()
+    void commitRecordsAsBatch_onlyPoisonPills_autoCommit_skipsRecordWithoutInjection()
             throws Exception {
-        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
-             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
-             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
-                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
-                             .thenReturn(omElement))) {
-            stubAxis2(bu, tu);
-            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+        callPrivate(consumer, "commitRecordsAsBatch",
+                new Class[]{ConsumerRecords.class},
+                makeRecords(TOPIC, 0, Collections.singletonList(
+                        poisonPillRecord(TOPIC, 0, 3L, "bad deser"))));
 
-            callPrivate(consumer, "commitRecordsAsBatch",
-                    new Class[]{ConsumerRecords.class},
-                    makeRecords(TOPIC, 0, Collections.singletonList(
-                            poisonPillRecord(TOPIC, 0, 3L, "bad deser"))));
-
-            verify(synapseEnvironment, atLeastOnce())
-                    .injectInbound(any(), eq(sequenceMediator), anyBoolean());
-            verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
-        }
+        verifyNoInteractions(synapseEnvironment);
+        verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
     }
 
     @Test
@@ -504,31 +376,22 @@ class KafkaMessageConsumerBatchTest {
         KafkaMessageConsumer mc = manualCommitConsumer();
         TopicPartition tp = new TopicPartition(TOPIC, 0);
 
-        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
-             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
-             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
-                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
-                             .thenReturn(omElement))) {
-            stubAxis2(bu, tu);
-            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+        callPrivate(mc, "commitRecordsAsBatch",
+                new Class[]{ConsumerRecords.class},
+                makeRecords(TOPIC, 0, Collections.singletonList(
+                        poisonPillRecord(TOPIC, 0, 5L, "deser failed"))));
 
-            callPrivate(mc, "commitRecordsAsBatch",
-                    new Class[]{ConsumerRecords.class},
-                    makeRecords(TOPIC, 0, Collections.singletonList(
-                            poisonPillRecord(TOPIC, 0, 5L, "deser failed"))));
-
-            @SuppressWarnings("unchecked")
-            ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
-                    ArgumentCaptor.forClass((Class) Map.class);
-            verify(mockKafkaConsumer).commitSync(captor.capture());
-            assertEquals(6L, captor.getValue().get(tp).offset());
-        }
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =
+                ArgumentCaptor.forClass((Class) Map.class);
+        verify(mockKafkaConsumer).commitSync(captor.capture());
+        assertEquals(6L, captor.getValue().get(tp).offset());
     }
 
     // ── commitRecordsAsBatch — mixed batch ─────────────────────────────────────
 
     @Test
-    void commitRecordsAsBatch_mixedBatch_poisonPillAndValidRecord_injectsBothSeparately()
+    void commitRecordsAsBatch_mixedBatch_poisonPillSkipped_validRecordInjected()
             throws Exception {
         KafkaMessageConsumer mc = manualCommitConsumer();
 
@@ -540,15 +403,15 @@ class KafkaMessageConsumerBatchTest {
             stubAxis2(bu, tu);
             when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
 
-            // offset 0 = poison pill, offset 1 = valid record
+            // offset 0 = poison pill (skipped), offset 1 = valid record (injected)
             callPrivate(mc, "commitRecordsAsBatch",
                     new Class[]{ConsumerRecords.class},
                     makeRecords(TOPIC, 0, Arrays.asList(
                             poisonPillRecord(TOPIC, 0, 0L, "err"),
                             record(TOPIC, 0, 1L, "ok".getBytes()))));
 
-            // first call: error sequence for poison pill; second call: inbound sequence for batch
-            verify(synapseEnvironment, times(2)).injectInbound(any(), any(), anyBoolean());
+            // only the valid record batch is injected; poison pill is logged and skipped
+            verify(synapseEnvironment, times(1)).injectInbound(any(), any(), anyBoolean());
             // offset committed: lastOffset(1) + 1 = 2
             @SuppressWarnings("unchecked")
             ArgumentCaptor<Map<TopicPartition, OffsetAndMetadata>> captor =

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -705,6 +705,100 @@ class KafkaMessageConsumerBatchTest {
         verify(mockDlqProducer).send(any(), any());
     }
 
+    // ── commitRecordsAsBatch — interleaved poison pill deduplication ──────────────
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void commitRecordsAsBatch_interleavedPoisonPill_onRetry_notRepublishedToDlq() throws Exception {
+        // [offset 10: valid, offset 11: poison pill, offset 12: valid]
+        // First call fails → seek back to 10. Second call presents the same records.
+        // The poison pill at 11 must be sent to the DLQ exactly once.
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        KafkaProducer<byte[], byte[]> mockDlqProducer = mock(KafkaProducer.class);
+        setField(mc, "dlqTopic", "dlq-topic");
+        setField(mc, "dlqProducer", mockDlqProducer);
+
+        ConsumerRecords<byte[], byte[]> batch = makeRecords(TOPIC, 0, Arrays.asList(
+                record(TOPIC, 0, 10L, "a".getBytes()),
+                poisonPillRecord(TOPIC, 0, 11L, "bad deser"),
+                record(TOPIC, 0, 12L, "b".getBytes())));
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch", new Class[]{ConsumerRecords.class}, batch);
+            callPrivate(mc, "commitRecordsAsBatch", new Class[]{ConsumerRecords.class}, batch);
+
+            verify(mockDlqProducer, times(1)).send(any(), any());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void commitRecordsAsBatch_poisonPillWithValidRecords_onSuccess_dlqPublishedOffsetsCleared()
+            throws Exception {
+        // After a successful batch commit the tracking set must be cleared so the
+        // next independent batch can re-use offset numbers without false dedup.
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        KafkaProducer<byte[], byte[]> mockDlqProducer = mock(KafkaProducer.class);
+        setField(mc, "dlqTopic", "dlq-topic");
+        setField(mc, "dlqProducer", mockDlqProducer);
+
+        ConsumerRecords<byte[], byte[]> batch = makeRecords(TOPIC, 0, Arrays.asList(
+                poisonPillRecord(TOPIC, 0, 5L, "bad deser"),
+                record(TOPIC, 0, 6L, "ok".getBytes())));
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(true);
+
+            callPrivate(mc, "commitRecordsAsBatch", new Class[]{ConsumerRecords.class}, batch);
+
+            Map<?, ?> tracking = (Map<?, ?>) getField(mc, "dlqPublishedOffsets");
+            assertTrue(tracking.isEmpty(),
+                    "dlqPublishedOffsets must be cleared after a successful commit");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void commitRecordsAsBatch_poisonPillWithValidRecords_onRetryExhaustion_dlqPublishedOffsetsCleared()
+            throws Exception {
+        KafkaMessageConsumer mc = manualCommitConsumer();
+        setField(mc, "retryCounter", 3); // already at failureRetryCount=3
+        KafkaProducer<byte[], byte[]> mockDlqProducer = mock(KafkaProducer.class);
+        setField(mc, "dlqTopic", "dlq-topic");
+        setField(mc, "dlqProducer", mockDlqProducer);
+
+        ConsumerRecords<byte[], byte[]> batch = makeRecords(TOPIC, 0, Arrays.asList(
+                poisonPillRecord(TOPIC, 0, 5L, "bad deser"),
+                record(TOPIC, 0, 6L, "ok".getBytes())));
+
+        try (MockedStatic<BuilderUtil> bu = mockStatic(BuilderUtil.class);
+             MockedStatic<TransportUtils> tu = mockStatic(TransportUtils.class);
+             MockedConstruction<SOAPBuilder> ignored = mockConstruction(SOAPBuilder.class,
+                     (m, ctx) -> when(m.processDocument(any(), anyString(), any()))
+                             .thenReturn(omElement))) {
+            stubAxis2(bu, tu);
+            when(synapseEnvironment.injectInbound(any(), any(), anyBoolean())).thenReturn(false);
+
+            callPrivate(mc, "commitRecordsAsBatch", new Class[]{ConsumerRecords.class}, batch);
+
+            Map<?, ?> tracking = (Map<?, ?>) getField(mc, "dlqPublishedOffsets");
+            assertTrue(tracking.isEmpty(),
+                    "dlqPublishedOffsets must be cleared after retry exhaustion commit");
+        }
+    }
+
     // ── commitRecordsAsBatch — null + valid mix, failure seek ──────────────────
 
     @Test

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -107,7 +107,7 @@ class KafkaMessageConsumerBatchTest {
         p.setProperty(KafkaConstants.POLL_TIMEOUT, "100");
         p.setProperty(KafkaConstants.TOPIC_NAME, TOPIC);
         p.setProperty(KafkaConstants.CONTENT_TYPE, "application/json");
-        p.setProperty(KafkaConstants.BATCH_MESSAGES_ENABLED, String.valueOf(batchEnabled));
+        p.setProperty(KafkaConstants.BATCH_PROCESSING_ENABLED, String.valueOf(batchEnabled));
         if (manualCommit) {
             p.setProperty(KafkaConstants.ENABLE_AUTO_COMMIT, "false");
             p.setProperty(KafkaConstants.FAILURE_RETRY_COUNT, "3");
@@ -583,13 +583,13 @@ class KafkaMessageConsumerBatchTest {
     @Test
     void isBatchEnabled_whenPropertySetToTrue_fieldIsTrue() throws Exception {
         assertTrue((Boolean) getField(consumer, "isBatchEnabled"),
-                "consumer created with batch.messages.enabled=true should have isBatchEnabled=true");
+                "consumer created with batch.processing.enabled=true should have isBatchEnabled=true");
     }
 
     @Test
     void isBatchEnabled_whenPropertyAbsent_defaultIsFalse() throws Exception {
         Properties props = baseProps(false, false);
-        props.remove(KafkaConstants.BATCH_MESSAGES_ENABLED);
+        props.remove(KafkaConstants.BATCH_PROCESSING_ENABLED);
         KafkaMessageConsumer c = new KafkaMessageConsumer(props, "ep",
                 synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
         assertFalse((Boolean) getField(c, "isBatchEnabled"),


### PR DESCRIPTION
## Summary

The Kafka inbound endpoint currently delivers polled records to the mediation sequence one-by-one, even though Kafka consumers fetch them in batches. This prevents use cases that benefit from bulk processing (e.g., batch inserts via DSS), and limits throughput.

This PR introduces **batch processing mode** for the Kafka inbound endpoint, allowing an entire polled batch to be forwarded to the sequence as a single message.

The per-record behavior remains the default — batch mode is to be opted into explicitly.

---

## New Parameters

### `batch.processing.enabled`

Enables batch mode. When `true`, all records fetched in a single poll are delivered to the sequence as one batched payload instead of individual messages.

```xml
<parameter name="batch.processing.enabled">true</parameter>
```

Default: `false`

---

### `kafka.dlq.topic`

Specifies a Dead Letter Queue (DLQ) topic for poison pills. Only applies when `batch.processing.enabled` is `true`. When a record cannot be deserialized, its raw bytes are forwarded to this topic rather than dropped or blocking the batch. 

```xml
<parameter name="kafka.dlq.topic">employees-dlq</parameter>
```

---

## Existing Parameter: `max.poll.records`

Controls how many records are fetched per poll. This parameter already existed; in batch mode it directly determines batch size. The default is `500` — increasing it improves throughput but raises memory usage proportionally.

```xml
<parameter name="max.poll.records">500</parameter>
```

---

## Payload Format

The payload delivered to the sequence differs by content type and mode. Given the following records stored in Kafka:

| Content Type | Example Record |
|---|---|
| `application/xml` | `<order><id>1</id><price>112</price></order>` |
| `application/json` | `{"id":1,"price":899}` |
| `text/plain` | `hello world` |

If the content type configured on the Kafka inbound endpoint does not match any of the above, `text/plain` is used as the default.

### Per-record mode (default)

The sequence receives each record as-is:

- `application/xml` → `<order><id>1</id><price>112</price></order>`
- `application/json` → `{"id":1,"price":899}`
- `text/plain` → `hello world`

### Batch mode (`batch.processing.enabled=true`)

All records from a poll are wrapped into a single payload. If a record is `null`, a warning is logged and that record is skipped.

**`application/xml`**
```xml
<messages>
  <order><id>1</id><price>90</price></order>
  <order><id>2</id><price>112</price></order>
</messages>
```

**`application/json`**
```json
[{"id":1,"price":12},{"id":2,"price":112}]
```

**`text/plain`**
```xml
<messages>
  <text>hello world</text>
  <text>hello world</text>
</messages>
```

---

## DLQ Behaviour 

- Poison pills (deserialization failures) are skipped from the batch and published to the configured DLQ topic.
- DLQ records carry provenance headers (`kafka_dlt-original-topic`, `kafka_dlt-original-partition`, `kafka_dlt-original-offset`, `kafka_dlt-original-timestamp`, `kafka_dlt-exception-message`, `kafka_dlt-exception-cause-message`), making them compatible with standard DLT consumers.
- DLQ sends are asynchronous (non-blocking) with a callback — they do not block the poll thread.
- Poison pill offsets are tracked per partition to prevent duplicate DLQ publishes when a batch is retried after a mediation failure.
- The DLQ producer is initialized only when batch processing is enabled and a DLQ topic is configured.

---

## Offset Commit Behavior

The offset commit mirrors the existing per-record behavior — the only difference is that commits now apply at the batch level rather than the record level. Retry logic is also similar to the per-record behavior

When `enable.auto.commit=false` and mediation fails; on a retry:

- The batch is seeked back to the first offset of each partition for retry.
- Once `failure.retry.count` is exhausted, offsets are committed and an error message is injected to the error sequence.

