### PR TITLE
fix: stop polling when suspend parameter is true

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaConstants.java
@@ -103,6 +103,7 @@ public class KafkaConstants {
     public static final String FAILURE_RETRY_COUNT = "failure.retry.count";
     public static final String FAILURE_RETRY_INTERVAL = "failure.retry.interval";
     public static final String TOPIC_PARTITIONS = "topic.partitions";
+    public static final String SUSPEND = "suspend";
     public static final String SASL_OAUTHBEARER_TOKEN_ENDPOINT = "sasl.oauthbearer.token.endpoint.url";
     public static final String SASL_OAUTHBEARER_SCOPE_CLAIM_NAME = "sasl.oauthbearer.scope.claim.name";
     public static final String SASL_LOGIN_CONNECT_TIMEOUT = "sasl.login.connect.timeout.ms";

--- a/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
+++ b/src/main/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumer.java
@@ -539,6 +539,10 @@ public class KafkaMessageConsumer extends GenericPollingConsumer {
      */
     private void populateOtherProperties(Properties properties) {
         checkDisableAutoCommit(properties);
+        isPaused = Boolean.parseBoolean(properties.getProperty(KafkaConstants.SUSPEND, "false"));
+        if (isPaused) {
+            log.info("Kafka consumer for " + name + " is suspended on startup due to 'suspend' parameter.");
+        }
         isBatchEnabled = Boolean.parseBoolean(
                 properties.getProperty(KafkaConstants.BATCH_PROCESSING_ENABLED,
                         KafkaConstants.BATCH_PROCESSING_ENABLED_DEFAULT));

--- a/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
+++ b/src/test/java/org/wso2/carbon/inbound/kafka/KafkaMessageConsumerBatchTest.java
@@ -44,6 +44,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
@@ -826,6 +827,37 @@ class KafkaMessageConsumerBatchTest {
             verify(mockKafkaConsumer).seek(tp, 7L);
             verify(mockKafkaConsumer, never()).commitSync(any(Map.class));
         }
+    }
+
+    // ── suspend configuration ───────────────────────────────────────────────────
+
+    @Test
+    void suspend_whenPropertySetToTrue_isPausedIsTrue() throws Exception {
+        Properties props = baseProps(true, false);
+        props.setProperty(KafkaConstants.SUSPEND, "true");
+        KafkaMessageConsumer c = new KafkaMessageConsumer(props, ENDPOINT_NAME,
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        assertTrue((Boolean) getField(c, "isPaused"),
+                "isPaused should be true when suspend property is set to true");
+    }
+
+    @Test
+    void suspend_whenPropertyAbsent_defaultIsFalse() throws Exception {
+        assertFalse((Boolean) getField(consumer, "isPaused"),
+                "isPaused should default to false when suspend property is absent");
+    }
+
+    @Test
+    void suspend_whenPropertySetToTrue_pollDoesNotConsumeRecords() throws Exception {
+        Properties props = baseProps(true, false);
+        props.setProperty(KafkaConstants.SUSPEND, "true");
+        KafkaMessageConsumer c = new KafkaMessageConsumer(props, ENDPOINT_NAME,
+                synapseEnvironment, 1000L, INBOUND_SEQ, ERROR_SEQ, false, true);
+        setField(c, "consumer", mockKafkaConsumer);
+
+        c.poll();
+
+        verify(mockKafkaConsumer, never()).poll(any(Duration.class));
     }
 
     // ── isBatchEnabled configuration ───────────────────────────────────────────


### PR DESCRIPTION
## Purpose

The Kafka inbound endpoint continues polling and consuming messages even when the `suspend` parameter is set to `true`.

This behavior prevents users from temporarily suspending Kafka message consumption through the inbound endpoint configuration. The expected behavior is that no polling operation should be performed while the inbound endpoint is suspended.

## Goals

* Stop Kafka polling when the `suspend` parameter is set to `true`.
* Prevent messages from being consumed while the inbound endpoint is suspended.
* Preserve the existing polling behavior when the `suspend` parameter is `false` or not configured.
* Avoid unnecessary calls to `KafkaConsumer.poll()` while the endpoint is suspended.

## Approach

The Kafka message consumer polling flow was updated to evaluate the value of the `suspend` parameter before initiating a polling operation.

When `suspend=true`, the consumer skips the polling operation and therefore does not retrieve or process records from Kafka.

When `suspend=false`, or when the parameter is not explicitly enabled, the existing polling behavior remains unchanged.

The change is limited to the Kafka consumer lifecycle and polling logic. It does not introduce new dependencies or affect any UI components.

## User stories

* As a Micro Integrator developer, I want to suspend a Kafka inbound endpoint so that it temporarily stops consuming messages.
* As an operations engineer, I want `suspend=true` to prevent Kafka polling without deleting or disabling the inbound endpoint configuration.
* As a user of the Kafka inbound endpoint, I expect normal message consumption to continue when suspension is not enabled.

## Release note

Fixed an issue where Kafka inbound endpoints continued polling and consuming messages when the `suspend` parameter was set to `true`.

## Documentation

N/A.

This change fixes the existing behavior of the `suspend` parameter and does not introduce a new configuration parameter or change the documented configuration syntax.

## Training

N/A.

This is a behavioral bug fix and does not introduce functionality that requires changes to the training content.

## Certification

N/A.

This bug fix does not introduce new product functionality or configuration concepts that would affect certification examinations.

## Marketing

N/A.

This is an internal behavioral fix and does not require marketing content.

## Automation tests

### Unit tests

* The project was successfully built using:

```bash
mvn clean install
```

* Code coverage: No new unit tests were added
* Added or updated test cases: KafkaMessageConsumerBatchTest.suspend_whenPropertySetToTrue_isPausedIsTrue(), KafkaMessageConsumerBatchTest.suspend_whenPropertyAbsent_defaultIsFalse(), KafkaMessageConsumerBatchTest.suspend_whenPropertySetToTrue_pollDoesNotConsumeRecords()

 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A.

This change fixes the runtime behavior of an existing Kafka inbound endpoint parameter and does not require a new sample.

The behavior can be validated with an inbound endpoint configuration containing:

```xml
<parameter name="suspend">true</parameter>
```

## Related PRs

N/A.

## Migrations (if applicable)

N/A.

No configuration, data, dependency, or deployment migration is required. Existing inbound endpoint configurations will continue to work without modification.

## Test environment

* WSO2 Micro Integrator: 4.6.0
* Kafka inbound extension: Built from this PR branch
* Apache Kafka: confluentinc/cp-kafka:7.8.0 image
* JDK: 21
* Maven: 3.9.12
* Operating system: ubuntu:25.10
* Database: N/A
* Browser: N/A
 
## Learning

The existing Kafka consumer lifecycle and polling implementation were reviewed to determine why the configured suspension state did not prevent message consumption.

The investigation showed that polling could continue without considering the `suspend` parameter. Since Kafka records are retrieved through `KafkaConsumer.poll()`, the suspension check must be performed before initiating the polling operation.

The implementation follows the existing project structure and Kafka consumer lifecycle. No new libraries, add-ons, or external dependencies were introduced.